### PR TITLE
Issue when maxInFlight === receiveBatchSize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -269,6 +269,6 @@ export default class Squiss extends EventEmitter {
    * @private
    */
   _slotsAvailable() {
-    return this._inFlight === 0 || this._inFlight < this._maxInFlight - this._receiveBatchSize;
+    return this._inFlight <= this._maxInFlight - this._receiveBatchSize;
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -269,6 +269,6 @@ export default class Squiss extends EventEmitter {
    * @private
    */
   _slotsAvailable() {
-    return this._inFlight < this._maxInFlight - this._receiveBatchSize;
+    return this._inFlight === 0 || this._inFlight < this._maxInFlight - this._receiveBatchSize;
   }
 }

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -125,6 +125,23 @@ describe('index', () => {
         });
       });
     });
+    it('receives batches of messages when maxInflight = receiveBatchSize', (done) => {
+      let msgs = 0;
+      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 10 });
+      inst.sqs = new SQSStub(15);
+      inst.start();
+      inst.on('message', (m) => {
+        msgs++;
+        m.del();
+      });
+      setImmediate(() => {
+        msgs.should.equal(10);
+        setImmediate(() => {
+          msgs.should.equal(15);
+          done();
+        });
+      });
+    });
     it('receives no messages', (done) => {
       let msgs = 0;
       inst = new Squiss({ queueUrl: 'foo' });

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -127,7 +127,7 @@ describe('index', () => {
     });
     it('receives batches of messages when maxInflight = receiveBatchSize', (done) => {
       let msgs = 0;
-      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 10 });
+      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 10, receiveBatchSize: 10 });
       inst.sqs = new SQSStub(15);
       inst.start();
       inst.on('message', (m) => {


### PR DESCRIPTION
When maxInFlight is set to the same value as receiveBatchSize the poller will grab one batch of messages and then stop. While I can't see many use cases where these two numbers should be the same (I only found it randomly in testing!), still probably worth a fix.

I went with adding a inFlight === 0 OR clause to _slotsAvailable