### PR TITLE
_delTimer should be nulled after it runs

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -131,6 +131,7 @@ export default class Squiss extends EventEmitter {
       this._deleteMessages(delBatch);
     } else if (!this._delTimer) {
       this._delTimer = setTimeout(() => {
+        this._delTimer = null;
         const delBatch = this._delQueue.splice(0, this._delQueue.length);
         this._deleteMessages(delBatch);
       }, this._deleteWaitMs);

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -181,7 +181,7 @@ describe('index', () => {
     });
     it('reports the correct number of inFlight messages', (done) => {
       let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 0 });
+      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 });
       inst.sqs = new SQSStub(5);
       inst.start();
       inst.on('message', (msg) => msgs.push(msg));
@@ -199,7 +199,7 @@ describe('index', () => {
   describe('Deleting', () => {
     it('deletes messages using internal API', (done) => {
       let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 0 });
+      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 });
       inst.sqs = new SQSStub(5);
       sinon.spy(inst.sqs, 'deleteMessageBatch');
       inst.start();
@@ -208,14 +208,14 @@ describe('index', () => {
         msgs.should.have.length(5);
         inst.deleteMessage(msgs.pop());
         setTimeout(() => {
-          inst.sqs.deleteMessageBatch.should.be.calledOnce;
+          inst.sqs.deleteMessageBatch.calledOnce.should.be.true;
           done();
         }, 10);
       });
     });
     it('deletes messages using Message API', (done) => {
       let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 0 });
+      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 });
       inst.sqs = new SQSStub(5);
       sinon.spy(inst.sqs, 'deleteMessageBatch');
       inst.start();
@@ -224,7 +224,7 @@ describe('index', () => {
         msgs.should.have.length(5);
         msgs.pop().del();
         setTimeout(() => {
-          inst.sqs.deleteMessageBatch.should.be.calledOnce;
+          inst.sqs.deleteMessageBatch.calledOnce.should.be.true;
           done();
         }, 10);
       });
@@ -239,9 +239,9 @@ describe('index', () => {
       setTimeout(() => {
         inst.stop();
         msgs.forEach((msg) => msg.del());
-        inst.sqs.deleteMessageBatch.should.be.calledOnce;
+        inst.sqs.deleteMessageBatch.calledOnce.should.be.true;
         setTimeout(() => {
-          inst.sqs.deleteMessageBatch.should.be.calledTwice;
+          inst.sqs.deleteMessageBatch.calledTwice.should.be.true;
           done();
         }, 20);
       }, 5);
@@ -256,7 +256,7 @@ describe('index', () => {
       setImmediate(() => {
         inst.stop();
         msgs[0].del();
-        inst.sqs.deleteMessageBatch.should.be.calledOnce;
+        inst.sqs.deleteMessageBatch.calledOnce.should.be.true;
         done();
       });
     });

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -260,6 +260,26 @@ describe('index', () => {
         done();
       });
     });
+    it('delWaitTime Timeout should be cleared after timeout runs', (done) => {
+      let msgs = [];
+      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 10, deleteWaitMs: 10});
+      inst.sqs = new SQSStub(2);
+      sinon.spy(inst, '_deleteMessages');
+      inst.start();
+      inst.on('message', (msg) => msgs.push(msg));
+      setTimeout(() => {
+        inst.stop();
+        msgs[0].del();
+        setTimeout(() => {
+          inst._deleteMessages.calledOnce.should.be.true;
+          msgs[1].del();
+          setTimeout(() => {
+            inst._deleteMessages.calledTwice.should.be.true;
+            done();
+          }, 20);
+        }, 20);
+      }, 5);
+    });
   });
   describe('Failures', () => {
     it('emits delError when a message fails to delete', (done) => {


### PR DESCRIPTION
Timeout was not being cleared after it was run. This was causing any message queued for deletion after to be held until the batchDeleteSize was reached.Under high load this is likely to go unnoticed but with a lighter load it is possible for a message to sit for well past its visibilityTimeout.

Also noticed a few of the tests where doing:
`inst.sqs.deleteMessageBatch.should.be.calledOnce`
instead of:
`inst.sqs.deleteMessageBatch.calledOnce.should.be.true`

This was hiding the fact that setting deleteWaitMs of 0 will default