### PR TITLE
Release candidate: 1.0

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,0 @@
-{
-  "stage": 1,
-  "optional": [ "es7.asyncFunctions" ]
-}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,34 +1,14 @@
 {
-  "parser": "babel-eslint",
   "env": {
     "node": true,
     "es6": true
-  },
-  "ecmaFeatures": {
-    "arrowFunctions": true,
-    "blockBindings": true,
-    "classes": true,
-    "defaultParams": true,
-    "destructuring": true,
-    "forOf": true,
-    "generators": false,
-    "modules": true,
-    "objectLiteralComputedProperties": true,
-    "objectLiteralDuplicateProperties": false,
-    "objectLiteralShorthandMethods": true,
-    "objectLiteralShorthandProperties": true,
-    "spread": true,
-    "superInFunctions": true,
-    "templateStrings": true,
-    "jsx": true
   },
   "rules": {
 /**
  * Strict mode
  */
-    // babel inserts "use strict"; for us
     // http://eslint.org/docs/rules/strict
-    "strict": [2, "never"],
+    "strict": [2, "global"],
 
 /**
  * ES6
@@ -95,12 +75,12 @@
     "no-loop-func": 2,               // http://eslint.org/docs/rules/no-loop-func
     "no-multi-str": 2,               // http://eslint.org/docs/rules/no-multi-str
     "no-native-reassign": 2,         // http://eslint.org/docs/rules/no-native-reassign
-    "no-new": 0,                     // http://eslint.org/docs/rules/no-new
+    "no-new": 2,                     // http://eslint.org/docs/rules/no-new
     "no-new-func": 2,                // http://eslint.org/docs/rules/no-new-func
     "no-new-wrappers": 2,            // http://eslint.org/docs/rules/no-new-wrappers
     "no-octal": 2,                   // http://eslint.org/docs/rules/no-octal
     "no-octal-escape": 2,            // http://eslint.org/docs/rules/no-octal-escape
-    "no-param-reassign": 2,          // http://eslint.org/docs/rules/no-param-reassign
+    "no-param-reassign": 0,          // http://eslint.org/docs/rules/no-param-reassign
     "no-proto": 2,                   // http://eslint.org/docs/rules/no-proto
     "no-redeclare": 2,               // http://eslint.org/docs/rules/no-redeclare
     "no-return-assign": 2,           // http://eslint.org/docs/rules/no-return-assign
@@ -153,16 +133,11 @@
     "no-underscore-dangle": 0,       // http://eslint.org/docs/rules/no-underscore-dangle
     "one-var": [2, "never"],         // http://eslint.org/docs/rules/one-var
     "padded-blocks": [2, "never"],   // http://eslint.org/docs/rules/padded-blocks
-    "semi": [ 2, "always" ],          // http://eslint.org/docs/rules/semi
-    "semi-spacing": [2, {            // http://eslint.org/docs/rules/semi-spacing
-      "before": false,
-      "after": true
-    }],
-    "space-after-keywords": 2,       // http://eslint.org/docs/rules/space-after-keywords
+    "semi": [ 2, "never" ],          // http://eslint.org/docs/rules/semi
+    "keyword-spacing": 2,       // http://eslint.org/docs/rules/space-after-keywords
     "space-before-blocks": 2,        // http://eslint.org/docs/rules/space-before-blocks
     "space-before-function-paren": [2, "never"], // http://eslint.org/docs/rules/space-before-function-paren
     "space-infix-ops": 2,            // http://eslint.org/docs/rules/space-infix-ops
-    "space-return-throw-case": 2,    // http://eslint.org/docs/rules/space-return-throw-case
     "spaced-comment": 2,        // http://eslint.org/docs/rules/spaced-line-comment
   }
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "4.2"
+  - "4"
+  - "5"
 after_script:
   - npm install -g codeclimate-test-reporter
   - codeclimate-test-reporter < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "4"
   - "5"
+  - "6"
 after_script:
   - npm install -g codeclimate-test-reporter
   - codeclimate-test-reporter < coverage/lcov.info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New option: activePollIntervalMs, allowing SQS requests to be spaced out when the queue has messages
 - New option: idlePollIntervalMs, allowing SQS requests to be spaced out when the queue is empty
 - `getQueueUrl` method to retrieve the configured queue's URL, even if only the name was provided to the constructor
+- `createQueue` method to create the configured queue
+- `deleteQueue` method to delete the configured queue
+- `sendMessage` method to send a message to the configured queue
+- `sendMessages` method to send an array of messages of any size (within reason) to the configured queue
 
 ### Changed
 - Dropped support for Node 0.12. For Node 0.12 support, consider compiling with an ES6 transpiler such as Babel, or using version 0.7.
 - Switched codebase to native ES6, updating to newest TechnologyAdvice style guide
+- `stop()` now aborts any ongoing receiveMessage request by default. It now accepts a `soft` argument (boolean) to soft-stop the poller without the abort functionality.
 
 ## [v0.7.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,17 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Development]
-Nothing yet!
+### Added
+- The `gotMessages` event, which fires when Squiss retrieves a new batch of messages from SQS
+- The `maxInFlight` event, which fires when Squiss stops requesting new messages due to hitting the maxInFlight cap
+- Documentation for the already-existing `drained` event
+- New option: activePollIntervalMs, allowing SQS requests to be spaced out when the queue has messages
+- New option: idlePollIntervalMs, allowing SQS requests to be spaced out when the queue is empty
+- `getQueueUrl` method to retrieve the configured queue's URL, even if only the name was provided to the constructor
+
+### Changed
+- Dropped support for Node 0.12. For Node 0.12 support, consider compiling with an ES6 transpiler such as Babel, or using version 0.7.
+- Switched codebase to native ES6, updating to newest TechnologyAdvice style guide
 
 ## [v0.7.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - `deleteQueue` method to delete the configured queue
 - `sendMessage` method to send a message to the configured queue
 - `sendMessages` method to send an array of messages of any size (within reason) to the configured queue
+- `deleteMessage` now accepts a ReceiptHandle string in lieu of a Message object, allowing messages to be deleted later without caching the full message itself.
 
 ### Changed
 - Dropped support for Node 0.12. For Node 0.12 support, consider compiling with an ES6 transpiler such as Babel, or using version 0.7.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - The `gotMessages` event, which fires when Squiss retrieves a new batch of messages from SQS
 - The `maxInFlight` event, which fires when Squiss stops requesting new messages due to hitting the maxInFlight cap
+- The `aborted` event, which fires when stop() is called during an active SQS receive message request
 - Documentation for the already-existing `drained` event
 - Documentation for the already-existing `sqs` property
 - `sqs` property is imbued with the magic of Bluebird.promisifyAll()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Documentation for the already-existing `sqs` property
 - New option: `activePollIntervalMs`, allowing SQS requests to be spaced out when the queue has messages
 - New option: `idlePollIntervalMs`, allowing SQS requests to be spaced out when the queue is empty
-- New option: `visibilityTimeoutSecs`, an alias for `visibilityTimeout` that stays consistent with the units suffix.
 - `getQueueUrl` method to retrieve the configured queue's URL, even if only the name was provided to the constructor
 - `createQueue` method to create the configured queue
 - `deleteQueue` method to delete the configured queue
@@ -22,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Dropped support for Node 0.12. For Node 0.12 support, consider compiling with an ES6 transpiler such as Babel, or using version 0.7.
 - Switched codebase to native ES6, updating to newest TechnologyAdvice style guide
 - `stop()` now aborts any ongoing receiveMessage request by default. It also accepts a `soft` argument (boolean) to soft-stop the poller without the abort functionality.
-- *DEPRECATED:* `opts.visibilityTimeout` is deprecated in favor of `opts.visibilityTimeoutSecs`. Usage of the old version will result in a message printed to stderr. It will be removed in a future version of Squiss.
+- `opts.visibilityTimeout` has been renamed to `opts.visibilityTimeoutSecs` for consistency.
 
 ## [v0.7.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `aborted` event, which fires when stop() is called during an active SQS receive message request
 - Documentation for the already-existing `drained` event
 - Documentation for the already-existing `sqs` property
-- `sqs` property is imbued with the magic of Bluebird.promisifyAll()
 - New option: `activePollIntervalMs`, allowing SQS requests to be spaced out when the queue has messages
 - New option: `idlePollIntervalMs`, allowing SQS requests to be spaced out when the queue is empty
 - New option: `visibilityTimeoutSecs`, an alias for `visibilityTimeout` that stays consistent with the units suffix.
@@ -22,7 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Dropped support for Node 0.12. For Node 0.12 support, consider compiling with an ES6 transpiler such as Babel, or using version 0.7.
 - Switched codebase to native ES6, updating to newest TechnologyAdvice style guide
-- `stop()` now aborts any ongoing receiveMessage request by default. It now accepts a `soft` argument (boolean) to soft-stop the poller without the abort functionality.
+- `stop()` now aborts any ongoing receiveMessage request by default. It also accepts a `soft` argument (boolean) to soft-stop the poller without the abort functionality.
 - *DEPRECATED:* `opts.visibilityTimeout` is deprecated in favor of `opts.visibilityTimeoutSecs`. Usage of the old version will result in a message printed to stderr. It will be removed in a future version of Squiss.
 
 ## [v0.7.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `gotMessages` event, which fires when Squiss retrieves a new batch of messages from SQS
 - The `maxInFlight` event, which fires when Squiss stops requesting new messages due to hitting the maxInFlight cap
 - Documentation for the already-existing `drained` event
+- Documentation for the already-existing `sqs` property
+- `sqs` property is imbued with the magic of Bluebird.promisifyAll()
 - New option: activePollIntervalMs, allowing SQS requests to be spaced out when the queue has messages
 - New option: idlePollIntervalMs, allowing SQS requests to be spaced out when the queue is empty
 - `getQueueUrl` method to retrieve the configured queue's URL, even if only the name was provided to the constructor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Documentation for the already-existing `drained` event
 - Documentation for the already-existing `sqs` property
 - `sqs` property is imbued with the magic of Bluebird.promisifyAll()
-- New option: activePollIntervalMs, allowing SQS requests to be spaced out when the queue has messages
-- New option: idlePollIntervalMs, allowing SQS requests to be spaced out when the queue is empty
+- New option: `activePollIntervalMs`, allowing SQS requests to be spaced out when the queue has messages
+- New option: `idlePollIntervalMs`, allowing SQS requests to be spaced out when the queue is empty
+- New option: `visibilityTimeoutSecs`, an alias for `visibilityTimeout` that stays consistent with the units suffix.
 - `getQueueUrl` method to retrieve the configured queue's URL, even if only the name was provided to the constructor
 - `createQueue` method to create the configured queue
 - `deleteQueue` method to delete the configured queue
@@ -21,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Dropped support for Node 0.12. For Node 0.12 support, consider compiling with an ES6 transpiler such as Babel, or using version 0.7.
 - Switched codebase to native ES6, updating to newest TechnologyAdvice style guide
 - `stop()` now aborts any ongoing receiveMessage request by default. It now accepts a `soft` argument (boolean) to soft-stop the poller without the abort functionality.
+- *DEPRECATED:* `opts.visibilityTimeout` is deprecated in favor of `opts.visibilityTimeoutSecs`. Usage of the old version will result in a message printed to stderr. It will be removed in a future version of Squiss.
 
 ## [v0.7.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -48,14 +48,17 @@ Squiss's defaults are great out of the box for most use cases, but you can use t
 ### squiss.deleteMessage(Message)
 Deletes a message. It's much easier to call `message.del()`, but if you need to do it right from the Squiss instance, this is how. Note that the message probably won't be deleted immediately -- it'll be queued for a batch delete. See the constructor notes for how to configure the specifics of that.
 
+### squiss.getQueueUrl()
+Returns a Promise that resolves with the URL of the configured queue, even if you only instantiated Squiss with a queueName. The correctQueueUrl setting applies to this result, if it was set.
+
 ### squiss.handledMessage()
 Informs Squiss that you got a message that you're not planning on deleting, so that Squiss can decrement the number of "in-flight" messages. It's good practice to delete every message you process, but this can be useful in case of error. You can also call `message.keep()` on the message itself to invoke this.
 
 ### squiss.start()
 Starts polling SQS for new messages. Each new message is handed off in the `message` event.
 
-### squiss.stop()
-Hold on to your hats, this one stops the polling. Note that if this is called while there's an active request for new messages, the message event may still be fired afterward.
+### squiss.stop(soft=`false`)
+Hold on to your hats, this one stops the polling. If called with soft=`true` while there's an active request for new messages, the active request will not be aborted and the message event may still be fired afterward.
 
 ## Properties
 
@@ -66,7 +69,7 @@ The number of messages currently in-flight.
 `true` if Squiss is actively polling SQS. If it's not polling, we made the genius design decision to have this set to `false`.
 
 ### {Object} squiss.sqs
-For your convenience, Squiss provides direct access to the AWS SDK's SQS object, which can be handy for setting up or tearing down tests. For our convenience _and_ yours, we've already called Bluebird's [promisifyAll](http://bluebirdjs.com/docs/api/promise.promisifyall.html) on this.
+For your convenience, Squiss provides direct access to the AWS SDK's SQS object, which can be handy for setting up or tearing down tests. No need to thank Squiss. Squiss does this because Squiss cares.
 
 ## Events
 
@@ -85,6 +88,9 @@ Emitted when Squiss asks SQS for a new batch of messages, and gets some (or one)
 
 ### queueEmpty
 Emitted when Squiss asks SQS for new messages, and doesn't get any.
+
+### aborted
+Emitted after a hard stop() if a request for new messages was already in progress.
 
 ### maxInFlight
 Emitted when Squiss has hit the maxInFlight cap. At this point, Squiss won't retrieve any more messages until at least `opts.receiveBatchSize` in-flight messages have been deleted.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Squiss [![Build Status](https://travis-ci.org/TechnologyAdvice/Squiss.svg?branch=master)](https://travis-ci.org/TechnologyAdvice/Squiss) [![Code Climate](https://codeclimate.com/github/TechnologyAdvice/Squiss/badges/gpa.svg)](https://codeclimate.com/github/TechnologyAdvice/Squiss) [![Test Coverage](https://codeclimate.com/github/TechnologyAdvice/Squiss/badges/coverage.svg)](https://codeclimate.com/github/TechnologyAdvice/Squiss/coverage)
-High-volume Amazon SQS Poller for Node.js
+High-volume Amazon SQS Poller and single-queue client for Node.js
 
 ```javascript
 const poller = new Squiss({
@@ -17,7 +17,7 @@ poller.on('message', (msg) => {
 ```
 
 ## How it works
-Squiss aims to process as many messages simultaneously as possible. Set the `maxInFlight` option to the number of messages your app can handle at one time without choking, and Squiss will attempt to keep that many messages flowing through your app, grabbing more as you mark each message as handled or ready for deletion. If the queue is empty, Squiss will maintain an open connection to SQS, waiting for any messages that appear in real time.
+Squiss aims to process as many messages simultaneously as possible. Set the `maxInFlight` option to the number of messages your app can handle at one time without choking, and Squiss will attempt to keep that many messages flowing through your app, grabbing more as you mark each message as handled or ready for deletion. If the queue is empty, Squiss will maintain an open connection to SQS, waiting for any messages that appear in real time. By default, anyway. You can configure it to poll however you want. Squiss don't care.
 
 ## Functions
 
@@ -26,11 +26,11 @@ Don't be scared of `new` -- you need to create a new Squiss instance for every q
 
 #### opts {...}
 Use the following options to point Squiss at the right queue:
-- **opts.awsConfig** An object mapping to pass to the SQS constructor, configuring the aws-sdk library. This is commonly used to set the AWS region, or the user credentials. See the docs on [configuring the aws-sdk](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) for details.
+- **opts.awsConfig** An object mapping to pass to the SQS constructor, configuring the aws-sdk library. This is commonly used to set the AWS region, endpoint, or the user credentials. See the docs on [configuring the aws-sdk](http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html) for details.
+- **opts.queueName** The name of the queue to be polled. Used only if opts.queueUrl is not specified, but Squiss prefers just the name.
 - **opts.queueUrl** The URL of the queue to be polled. If not specified, opts.queueName is required.
-- **opts.queueName** The name of the queue to be polled. Used only if opts.queueUrl is not specified.
 - **opts.accountNumber** If a queueName is specified, the accountNumber of the queue owner can optionally be specified to access a queue in a different AWS account.
-- **opts.correctQueueUrl** _Default false._ Changes the protocol, host, and port of the queue URL to match the configured SQS endpoint, applicable only if opts.queueName is specified. This can be useful for testing against a stubbed SQS service, such as ElasticMQ.
+- **opts.correctQueueUrl** _Default false._ Changes the protocol, host, and port of the queue URL to match the configured SQS endpoint (see opts.awsConfig), applicable only if opts.queueName is specified. This can be useful for testing against a local SQS service, such as ElasticMQ.
 
 Squiss's defaults are great out of the box for most use cases, but you can use the below to fine-tune your Squiss experience:
 - **opts.activePollIntervalMs** _Default 0._ The number of milliseconds to wait between requesting batches of messages when the queue is not empty, and the maxInFlight cap has not been hit. For most use cases, it's better to leave this at 0 and let Squiss manage the active polling frequency according to maxInFlight.
@@ -45,8 +45,21 @@ Squiss's defaults are great out of the box for most use cases, but you can use t
 - **opts.unwrapSns** _Default false._ Set to `true` to denote that Squiss should treat each message as though it comes from a queue subscribed to an SNS endpoint, and automatically extract the message from the SNS metadata wrapper.
 - **opts.visibilityTimeout** The SQS VisibilityTimeout to apply to each message. This is the number of seconds that each received message should be made inaccessible to other receive calls, so that a message will not be received more than once before it is processed and deleted. If not specified, the default for the SQS queue will be used.
 
+Are you using Squiss to create your queue, as well? Consider setting any of the following options. Note that the defaults are the same as Amazon's own:
+- **opts.delaySecs** _Default 0._ The number of milliseconds by which to delay the delivery of new messages into the queue by default.
+- **opts.maxMessageBytes** _Default 262144 (256KB)._ The maximum size of a single message, in bytes, that the queue can support.
+- **opts.messageRetentionSecs** _Default 345600 (4 days)._ The amount of time for which to retain messages in the queue until they expire, in seconds. Maximum is 1209600 (14 days).
+- **opts.queuePolicy** If specified, will be set as the access policy of the queue when `createQueue` is called. See [the AWS Policy documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) for more information.
+- **opts.visibilityTimeoutSecs** _Default 30._ The amount of time, in seconds, that received messages will be unavailable to other pollers without being deleted.
+
+### squiss.createQueue()
+Creates the configured queue! This returns a promise that resolves with the new queue's URL when it's complete. Note that this can only be called if you set `opts.queueName` when instantiating Squiss.
+
 ### squiss.deleteMessage(Message)
 Deletes a message. It's much easier to call `message.del()`, but if you need to do it right from the Squiss instance, this is how. Note that the message probably won't be deleted immediately -- it'll be queued for a batch delete. See the constructor notes for how to configure the specifics of that.
+
+### squiss.deleteQueue()
+Deletes the configured queue, returning a promise that resolves on complete. Squiss lets you do this, even though it makes Squiss useless. Squiss is so selfless.
 
 ### squiss.getQueueUrl()
 Returns a Promise that resolves with the URL of the configured queue, even if you only instantiated Squiss with a queueName. The correctQueueUrl setting applies to this result, if it was set.
@@ -54,11 +67,36 @@ Returns a Promise that resolves with the URL of the configured queue, even if yo
 ### squiss.handledMessage()
 Informs Squiss that you got a message that you're not planning on deleting, so that Squiss can decrement the number of "in-flight" messages. It's good practice to delete every message you process, but this can be useful in case of error. You can also call `message.keep()` on the message itself to invoke this.
 
+### squiss.sendMessage(message, delay, attributes)
+Sends an individual message to the configured queue, and returns a promise that resolves with AWS's official message metadata: an object containing `MessageId`, `MD5OfMessageAttributes`, and `MD5OfMessageBody`. Arguments:
+- **message**. The message to push to the queue. If it's a string, great! If it's an Object, Squiss will call JSON.stringify on it.
+- **delay** _optional_. The amount of time, in seconds, to wait before making the message available in the queue. If not specified, the queue's configured value will be used.
+- **attributes** _optional_. An optional attributes mapping to associate with the message. For more information, see [the official AWS documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#sendMessage-property).
+
+### squiss.sendMessages(messages, delay, attributes)
+Sends an array of any number of messages to the configured SQS queue, breaking them down into appropriate batch requests executed in parallel (or as much as the default HTTP agent allows). It returns a promise that resolves with a response closely aligned to the official AWS SDK's sendMessageBatch, except the results from all batch requests are merged. Expect a result similar to:
+
+```javascript
+{
+  Successful: [
+    {Id: string, MessageId: string, MD5OfMessageAttributes: string, MD5OfMessageBody: string}
+  ],
+  Failed: [
+    {Id: string, SenderFault: boolean, Code: string, Message: string}
+  ]
+}
+```
+
+The "Id" supplied in the response will be the index of the message in the original messages array, in string form. Arguments:
+- **messages**. The array of messages to push to the queue. The messages should be either strings, or Objects that Squiss can pass to JSON.stringify.
+- **delay** _optional_. The amount of time, in seconds, to wait before making the messages available in the queue. If not specified, the queue's configured value will be used.
+- **attributes** _optional_. An optional attributes mapping to associate with each message. For more information, see [the official AWS documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#sendMessage-property).
+
 ### squiss.start()
 Starts polling SQS for new messages. Each new message is handed off in the `message` event.
 
 ### squiss.stop(soft=`false`)
-Hold on to your hats, this one stops the polling. If called with soft=`true` while there's an active request for new messages, the active request will not be aborted and the message event may still be fired afterward.
+Hold on to your hats, this one stops the polling, aborting any in-progress request for new messages. If called with soft=`true` while there's an active request for new messages, the active request will not be aborted and the message event may still be fired up to `opts.receiveWaitTimeSecs` afterward.
 
 ## Properties
 

--- a/README.md
+++ b/README.md
@@ -43,14 +43,13 @@ Squiss's defaults are great out of the box for most use cases, but you can use t
 - **opts.receiveBatchSize** _Default 10._ The number of messages to receive at one time. Maximum 10 or maxInFlight, whichever is lower.
 - **opts.receiveWaitTimeSecs** _Default 20._ The number of seconds for which to hold open the SQS call to receive messages, when no message is currently available. It is recommended to set this high, as Squiss will re-open the receiveMessage HTTP request as soon as the last one ends. If this needs to be set low, consider setting activePollIntervalMs to space out calls to SQS. Maximum 20.
 - **opts.unwrapSns** _Default false._ Set to `true` to denote that Squiss should treat each message as though it comes from a queue subscribed to an SNS endpoint, and automatically extract the message from the SNS metadata wrapper.
-- **opts.visibilityTimeout** The SQS VisibilityTimeout to apply to each message. This is the number of seconds that each received message should be made inaccessible to other receive calls, so that a message will not be received more than once before it is processed and deleted. If not specified, the default for the SQS queue will be used.
+- **opts.visibilityTimeoutSecs** _Defaults to queue setting on read, or 30 seconds for createQueue._ The amount of time, in seconds, that received messages will be unavailable to other pollers without being deleted.
 
-Are you using Squiss to create your queue, as well? Consider setting any of the following options. Note that the defaults are the same as Amazon's own:
+Are you using Squiss to create your queue, as well? Squiss will use `opts.receiveWaitTimeSecs` and `opts.visibilityTimeoutSecs` above in the queue settings, but consider setting any of the following options to configure it further. Note that the defaults are the same as Amazon's own:
 - **opts.delaySecs** _Default 0._ The number of milliseconds by which to delay the delivery of new messages into the queue by default.
 - **opts.maxMessageBytes** _Default 262144 (256KB)._ The maximum size of a single message, in bytes, that the queue can support.
 - **opts.messageRetentionSecs** _Default 345600 (4 days)._ The amount of time for which to retain messages in the queue until they expire, in seconds. Maximum is 1209600 (14 days).
 - **opts.queuePolicy** If specified, will be set as the access policy of the queue when `createQueue` is called. See [the AWS Policy documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html) for more information.
-- **opts.visibilityTimeoutSecs** _Default 30._ The amount of time, in seconds, that received messages will be unavailable to other pollers without being deleted.
 
 ### squiss.createQueue()
 Creates the configured queue! This returns a promise that resolves with the new queue's URL when it's complete. Note that this can only be called if you set `opts.queueName` when instantiating Squiss.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Squiss [![Build Status](https://travis-ci.org/TechnologyAdvice/Squiss.svg?branch=master)](https://travis-ci.org/TechnologyAdvice/Squiss) [![Code Climate](https://codeclimate.com/github/TechnologyAdvice/Squiss/badges/gpa.svg)](https://codeclimate.com/github/TechnologyAdvice/Squiss) [![Test Coverage](https://codeclimate.com/github/TechnologyAdvice/Squiss/badges/coverage.svg)](https://codeclimate.com/github/TechnologyAdvice/Squiss/coverage)
-High-volume Amazon SQS Poller and single-queue client for Node.js
+High-volume Amazon SQS Poller and single-queue client for Node.js 4 and up
 
 ```javascript
 const poller = new Squiss({
@@ -54,8 +54,8 @@ Are you using Squiss to create your queue, as well? Squiss will use `opts.receiv
 ### squiss.createQueue()
 Creates the configured queue! This returns a promise that resolves with the new queue's URL when it's complete. Note that this can only be called if you set `opts.queueName` when instantiating Squiss.
 
-### squiss.deleteMessage(Message)
-Deletes a message. It's much easier to call `message.del()`, but if you need to do it right from the Squiss instance, this is how. Note that the message probably won't be deleted immediately -- it'll be queued for a batch delete. See the constructor notes for how to configure the specifics of that.
+### squiss.deleteMessage(message|receiptHandle)
+Deletes a message, given either the full Message object sent to the `message` event, or the message's ReceiptHandle string. It's much easier to call `message.del()`, but if you need to do it right from the Squiss instance, this is how. Note that the message probably won't be deleted immediately -- it'll be queued for a batch delete. See the constructor notes for how to configure the specifics of that.
 
 ### squiss.deleteQueue()
 Deletes the configured queue, returning a promise that resolves on complete. Squiss lets you do this, even though it makes Squiss useless. Squiss is so selfless.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run lint && npm run test-cov && npm run check-cov",
     "mocha": "mocha",
     "test-cov": "istanbul cover _mocha",
-    "check-cov": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
+    "check-cov": "istanbul check-coverage --statements 96 --branches 94 --functions 100 --lines 96",
     "lint": "eslint ./src ./test",
     "prepublish": "npm test && npm run build"
   },
@@ -35,13 +35,16 @@
   },
   "homepage": "https://github.com/TechnologyAdvice/Squiss#readme",
   "dependencies": {
-    "aws-sdk": "^2.3.5"
+    "aws-sdk": "^2.3.5",
+    "bluebird": "^3.3.5"
   },
   "devDependencies": {
     "chai": "^3.5.0",
+    "delay": "^1.3.1",
     "eslint": "^2.8.0",
     "istanbul": "^0.4.3",
     "mocha": "^2.4.5",
-    "sinon": "^1.17.3"
+    "sinon": "^1.17.3",
+    "sinon-chai": "^2.8.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "main": "src/index.js",
   "scripts": {
     "clean": "rm -rf node_modules build coverage",
-    "test": "npm run lint && npm run test-cov",
+    "test": "npm run lint && npm run test-cov && npm run check-cov",
     "mocha": "mocha",
     "test-cov": "istanbul cover _mocha",
-    "check-cov": "istanbul check-coverage --statements 96 --branches 94 --functions 100 --lines 96",
+    "check-cov": "istanbul check-coverage --statements 97 --branches 94 --functions 100 --lines 96",
     "lint": "eslint ./src ./test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run lint && npm run test-cov && npm run check-cov",
     "mocha": "mocha",
     "test-cov": "istanbul cover _mocha",
-    "check-cov": "istanbul check-coverage --statements 97 --branches 94 --functions 100 --lines 96",
+    "check-cov": "istanbul check-coverage --statements 96 --branches 93 --functions 100 --lines 96",
     "lint": "eslint ./src ./test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.7.0",
   "description": "High-volume SQS poller",
   "main": "src/index.js",
+  "engines": {
+    "node": ">=4.2"
+  },
   "scripts": {
     "clean": "rm -rf node_modules build coverage",
     "test": "npm run lint && npm run test-cov && npm run check-cov",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "npm run lint && npm run test-cov && npm run check-cov",
     "mocha": "mocha",
     "test-cov": "istanbul cover _mocha",
-    "check-cov": "istanbul check-coverage --statements 96 --branches 93 --functions 100 --lines 96",
+    "check-cov": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "lint": "eslint ./src ./test"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "mocha": "mocha",
     "test-cov": "istanbul cover _mocha",
     "check-cov": "istanbul check-coverage --statements 96 --branches 94 --functions 100 --lines 96",
-    "lint": "eslint ./src ./test",
-    "prepublish": "npm test && npm run build"
+    "lint": "eslint ./src ./test"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,14 +2,13 @@
   "name": "squiss",
   "version": "0.7.0",
   "description": "High-volume SQS poller",
-  "main": "build/index.js",
+  "main": "src/index.js",
   "scripts": {
     "clean": "rm -rf node_modules build coverage",
-    "build": "babel ./src --out-dir ./build",
     "test": "npm run lint && npm run test-cov && npm run check-cov",
-    "mocha": "babel-node node_modules/.bin/_mocha",
-    "test-cov": "babel-node node_modules/.bin/babel-istanbul cover node_modules/.bin/_mocha",
-    "check-cov": "babel-istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
+    "mocha": "mocha",
+    "test-cov": "istanbul cover _mocha",
+    "check-cov": "istanbul check-coverage --statements 100 --branches 100 --functions 100 --lines 100",
     "lint": "eslint ./src ./test",
     "prepublish": "npm test && npm run build"
   },
@@ -18,7 +17,7 @@
     "url": "git+https://github.com/TechnologyAdvice/Squiss.git"
   },
   "files": [
-    "build"
+    "src"
   ],
   "keywords": [
     "aws",
@@ -36,15 +35,13 @@
   },
   "homepage": "https://github.com/TechnologyAdvice/Squiss#readme",
   "dependencies": {
-    "aws-sdk": "^2.2.15"
+    "aws-sdk": "^2.3.5"
   },
   "devDependencies": {
-    "babel": "^5.8.29",
-    "babel-eslint": "^4.1.5",
-    "babel-istanbul": "^0.4.1",
-    "chai": "^3.4.1",
-    "eslint": "^1.9.0",
-    "mocha": "^2.3.3",
-    "sinon": "^1.17.2"
+    "chai": "^3.5.0",
+    "eslint": "^2.8.0",
+    "istanbul": "^0.4.3",
+    "mocha": "^2.4.5",
+    "sinon": "^1.17.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "clean": "rm -rf node_modules build coverage",
-    "test": "npm run lint && npm run test-cov && npm run check-cov",
+    "test": "npm run lint && npm run test-cov",
     "mocha": "mocha",
     "test-cov": "istanbul cover _mocha",
     "check-cov": "istanbul check-coverage --statements 96 --branches 94 --functions 100 --lines 96",
@@ -34,8 +34,7 @@
   },
   "homepage": "https://github.com/TechnologyAdvice/Squiss#readme",
   "dependencies": {
-    "aws-sdk": "^2.3.5",
-    "bluebird": "^3.3.5"
+    "aws-sdk": "^2.3.5"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/Message.js
+++ b/src/Message.js
@@ -1,6 +1,8 @@
 /*
- * Copyright (c) 2015 TechnologyAdvice
+ * Copyright (c) 2015-2016 TechnologyAdvice
  */
+
+'use strict'
 
 /**
  * The message class is a wrapper for Amazon SQS messages that provides the raw and parsed message body,
@@ -21,18 +23,18 @@ class Message {
    *    delete the message and update inFlight count tracking.
    */
   constructor(opts) {
-    this.raw = opts.msg;
-    this.body = opts.msg.Body;
+    this.raw = opts.msg
+    this.body = opts.msg.Body
     if (opts.unwrapSns) {
-      let unwrapped = JSON.parse(this.body);
-      this.body = unwrapped.Message;
-      this.subject = unwrapped.Subject;
-      this.topicArn = unwrapped.TopicArn;
-      this.topicName = unwrapped.TopicArn.substr(unwrapped.TopicArn.lastIndexOf(':') + 1);
+      let unwrapped = JSON.parse(this.body)
+      this.body = unwrapped.Message
+      this.subject = unwrapped.Subject
+      this.topicArn = unwrapped.TopicArn
+      this.topicName = unwrapped.TopicArn.substr(unwrapped.TopicArn.lastIndexOf(':') + 1)
     }
-    this.body = Message._formatMessage(this.body, opts.bodyFormat);
-    this._squiss = opts.squiss;
-    this._handled = false;
+    this.body = Message._formatMessage(this.body, opts.bodyFormat)
+    this._squiss = opts.squiss
+    this._handled = false
   }
 
   /**
@@ -40,8 +42,8 @@ class Message {
    */
   del() {
     if (!this._handled) {
-      this._squiss.deleteMessage(this);
-      this._handled = true;
+      this._squiss.deleteMessage(this)
+      this._handled = true
     }
   }
 
@@ -50,8 +52,8 @@ class Message {
    */
   keep() {
     if (!this._handled) {
-      this._squiss.handledMessage();
-      this._handled = true;
+      this._squiss.handledMessage()
+      this._handled = true
     }
   }
 }
@@ -65,9 +67,9 @@ class Message {
  */
 Message._formatMessage = (msg, format) => {
   switch (format) {
-  case 'json': return JSON.parse(msg);
-  default: return msg;
+  case 'json': return JSON.parse(msg)
+  default: return msg
   }
-};
+}
 
-export default Message;
+module.exports = Message

--- a/src/index.js
+++ b/src/index.js
@@ -111,10 +111,6 @@ class Squiss extends EventEmitter {
     this._delQueue = []
     this._delTimer = null
     this._queueUrl = opts.queueUrl
-    if (opts.visibilityTimeout && !opts.visibilityTimeoutSecs) {
-      this._opts.visibilityTimeoutSecs = opts.visibilityTimeout
-      process.stderr.write('DEPRECATED: Squiss: Use opts.visibilityTimeoutSecs instead of opts.visibilityTimeout.\n')
-    }
     if (!opts.queueUrl && !opts.queueName) {
       throw new Error('Squiss requires either the "queueUrl", or the "queueName".')
     }

--- a/src/index.js
+++ b/src/index.js
@@ -170,10 +170,14 @@ class Squiss extends EventEmitter {
   /**
    * Queues the given message for deletion. The message will actually be deleted from SQS per the settings
    * supplied to the constructor.
-   * @param {Message} msg The message to be deleted.
+   * @param {Message|string} msg The message object to be deleted, or the receipt handle of a message to be deleted
    */
   deleteMessage(msg) {
-    this._delQueue.push({ Id: msg.raw.MessageId, ReceiptHandle: msg.raw.ReceiptHandle })
+    if (msg instanceof Message) {
+      this._delQueue.push({ Id: msg.raw.MessageId, ReceiptHandle: msg.raw.ReceiptHandle })
+    } else {
+      this._delQueue.push({ Id: msg, ReceiptHandle: msg })
+    }
     this.handledMessage()
     if (this._delQueue.length >= this._opts.deleteBatchSize) {
       if (this._delTimer) {

--- a/src/index.js
+++ b/src/index.js
@@ -207,7 +207,7 @@ class Squiss extends EventEmitter {
     if (this._queueUrl) return Promise.resolve(this._queueUrl)
     const params = { QueueName: this._opts.queueName }
     if (this._opts.accountNumber) {
-      params.QueueOwnerAWSAccountId = this._opts.accountNumber
+      params.QueueOwnerAWSAccountId = this._opts.accountNumber.toString()
     }
     return this.sqs.getQueueUrl(params).promise().then(data => {
       this._queueUrl = data.QueueUrl

--- a/src/index.js
+++ b/src/index.js
@@ -275,7 +275,8 @@ class Squiss extends EventEmitter {
    *
    * See http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#sendMessageBatch-property for full details.
    * The "Id" supplied in the response will be the index of the message in the original messages array, in string form.
-   * @param {Array<string|Object>} messages An array of messages to be sent. Objects will be JSON.stringified.
+   * @param {string|Object||Array<string|Object>} messages An array of messages to be sent. Objects will be
+   *    JSON.stringified.
    * @param {number} [delay] The number of seconds by which to delay the delivery of the messages, max 900. If not
    *    specified, the queue default will be used.
    * @param {Object} [attributes] An optional attributes mapping to associate with all messages. For more information,
@@ -296,12 +297,8 @@ class Squiss extends EventEmitter {
     })).then((results) => {
       const merged = {Successful: [], Failed: []}
       results.forEach((res) => {
-        if (res.Successful) {
-          res.Successful.forEach(elem => merged.Successful.push(elem))
-        }
-        if (res.Failed) {
-          res.Failed.forEach(elem => merged.Failed.push(elem))
-        }
+        res.Successful.forEach(elem => merged.Successful.push(elem))
+        res.Failed.forEach(elem => merged.Failed.push(elem))
       })
       return merged
     })
@@ -441,9 +438,6 @@ class Squiss extends EventEmitter {
    * @private
    */
   _sendMessageBatch(messages, delay, attributes, startIndex) {
-    if (!Array.isArray(messages) || messages.length > AWS_MAX_SEND_BATCH) {
-      return Promise.reject(`messages must be an array of ${AWS_MAX_SEND_BATCH} messages at most.`)
-    }
     const start = startIndex || 0
     return this.getQueueUrl().then((queueUrl) => {
       const params = {

--- a/src/index.js
+++ b/src/index.js
@@ -101,6 +101,7 @@ class Squiss extends EventEmitter {
    */
   constructor(opts) {
     super()
+    opts = opts || {}
     this.sqs = new AWS.SQS(opts.awsConfig)
     this._opts = {}
     Object.assign(this._opts, optDefaults, opts)

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,12 @@
+{
+  "env": {
+    "mocha": true
+  },
+  "globals": {
+    "sinon": false,
+    "should": false
+  },
+  "rules": {
+    "no-new": 0
+  }
+}

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,15 +1,17 @@
 /*
- * Copyright (c) 2015 TechnologyAdvice
+ * Copyright (c) 2015-2016 TechnologyAdvice
  */
 
-import chai from 'chai';
-import path from 'path';
-import module from 'module';
-import sinon from 'sinon';
+'use strict'
 
-global.should = chai.should();
-global.sinon = sinon;
+const chai = require('chai')
+const path = require('path')
+const mod = require('module')
+const sinon = require('sinon')
+
+global.should = chai.should()
+global.sinon = sinon
 
 // importing files with ../../../../../.. makes my brain hurt
-process.env.NODE_PATH = path.join(__dirname, '..') + path.delimiter + (process.env.NODE_PATH || '');
-module._initPaths();
+process.env.NODE_PATH = path.join(__dirname, '..') + path.delimiter + (process.env.NODE_PATH || '')
+mod._initPaths()

--- a/test/setup.js
+++ b/test/setup.js
@@ -8,6 +8,9 @@ const chai = require('chai')
 const path = require('path')
 const mod = require('module')
 const sinon = require('sinon')
+const sinonChai = require('sinon-chai')
+
+chai.use(sinonChai)
 
 global.should = chai.should()
 global.sinon = sinon

--- a/test/src/Message.spec.js
+++ b/test/src/Message.spec.js
@@ -1,8 +1,10 @@
 /*
- * Copyright (c) 2015 TechnologyAdvice
+ * Copyright (c) 2015-2016 TechnologyAdvice
  */
 
-import Message from 'src/Message';
+'use strict'
+
+const Message = require('src/Message')
 
 function getSQSMsg(body) {
   return {
@@ -10,7 +12,7 @@ function getSQSMsg(body) {
     ReceiptHandle: 'handle',
     MD5OfBody: 'abcdeabcdeabcdeabcdeabcdeabcde12',
     Body: body
-  };
+  }
 }
 
 const snsMsg = {
@@ -24,7 +26,7 @@ const snsMsg = {
   Signature: 'dGVzdAo=',
   SigningCertURL: 'https://sns.us-east-1.amazonaws.com/SimpleNotificationService-bb750dd426d95ee9390147a5624348ee.pem',
   UnsubscribeURL: 'https://sns.us-east-1.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-east-1:1234567890:sns-topic-name:12345678-1234-4321-1234-123456789012'
-};
+}
 
 describe('Message', () => {
   it('unwraps an SNS message', () => {
@@ -32,35 +34,35 @@ describe('Message', () => {
       msg: getSQSMsg(JSON.stringify(snsMsg)),
       unwrapSns: true,
       bodyFormat: 'plain'
-    });
-    msg.should.have.property('body').equal('foo');
-    msg.should.have.property('subject').equal('some-subject');
-    msg.should.have.property('topicArn').equal(snsMsg.TopicArn);
-    msg.should.have.property('topicName').equal('sns-topic-name');
-  });
+    })
+    msg.should.have.property('body').equal('foo')
+    msg.should.have.property('subject').equal('some-subject')
+    msg.should.have.property('topicArn').equal(snsMsg.TopicArn)
+    msg.should.have.property('topicName').equal('sns-topic-name')
+  })
   it('parses JSON', () => {
     const msg = new Message({
       msg: getSQSMsg('{"Message":"foo","bar":"baz"}'),
       bodyFormat: 'json'
-    });
-    msg.should.have.property('body');
-    msg.body.should.be.an.Object;
-    msg.body.should.have.property('Message').equal('foo');
-    msg.body.should.have.property('bar').equal('baz');
-  });
+    })
+    msg.should.have.property('body')
+    msg.body.should.be.an.Object
+    msg.body.should.have.property('Message').equal('foo')
+    msg.body.should.have.property('bar').equal('baz')
+  })
   it('calls Squiss.deleteMessage on delete', (done) => {
     const msg = new Message({
       msg: getSQSMsg('{"Message":"foo","bar":"baz"}'),
       bodyFormat: 'json',
       squiss: {
         deleteMessage: (toDel) => {
-          toDel.should.equal(msg);
-          done();
+          toDel.should.equal(msg)
+          done()
         }
       }
-    });
-    msg.del();
-  });
+    })
+    msg.del()
+  })
   it('calls Squiss.handledMessage on keep', (done) => {
     const msg = new Message({
       msg: getSQSMsg('{"Message":"foo","bar":"baz"}'),
@@ -68,22 +70,22 @@ describe('Message', () => {
       squiss: {
         handledMessage: () => done()
       }
-    });
-    msg.keep();
-  });
+    })
+    msg.keep()
+  })
   it('treats del() and keep() as idempotent', () => {
-    let calls = 0;
+    let calls = 0
     const msg = new Message({
       msg: getSQSMsg('{"Message":"foo","bar":"baz"}'),
       bodyFormat: 'json',
       squiss: {
-        deleteMessage: () => calls += 1,
-        handledMessage: () => calls += 10
+        deleteMessage: () => { calls += 1 },
+        handledMessage: () => { calls += 10 }
       }
-    });
-    msg.del();
-    msg.keep();
-    msg.del();
-    calls.should.equal(1);
-  });
-});
+    })
+    msg.del()
+    msg.keep()
+    msg.del()
+    calls.should.equal(1)
+  })
+})

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -1,394 +1,396 @@
 /*
- * Copyright (c) 2015 TechnologyAdvice
+ * Copyright (c) 2015-2016 TechnologyAdvice
  */
 
-import AWS from 'aws-sdk';
-import Squiss from 'src/index';
-import SQSStub from 'test/stubs/SQSStub';
+'use strict'
 
-let inst = null;
-const origSQS = AWS.SQS;
+const AWS = require('aws-sdk')
+const Squiss = require('src/index')
+const SQSStub = require('test/stubs/SQSStub')
+
+let inst = null
+const origSQS = AWS.SQS
 
 describe('index', () => {
   afterEach(() => {
-    if (inst) inst.stop();
-    inst = null;
-    AWS.SQS = origSQS;
-  });
+    if (inst) inst.stop()
+    inst = null
+    AWS.SQS = origSQS
+  })
   describe('constructor', () => {
     it('creates a new Squiss instance', () => {
       inst = new Squiss({
         queueUrl: 'foo',
         unwrapSns: true,
         visibilityTimeout: 10
-      });
-      should.exist(inst);
-    });
+      })
+      should.exist(inst)
+    })
     it('fails if queue is not specified', () => {
-      let errored = false;
+      let errored = false
       try {
-        new Squiss();
+        new Squiss()
       } catch (e) {
-        should.exist(e);
-        e.should.be.instanceOf(Error);
-        errored = true;
+        should.exist(e)
+        e.should.be.instanceOf(Error)
+        errored = true
       }
-      errored.should.be.true;
-    });
+      errored.should.be.true
+    })
     it('provides a configured sqs client instance', () => {
       inst = new Squiss({
         queueUrl: 'foo',
         awsConfig: {
           region: 'us-east-1'
         }
-      });
-      inst.should.have.property('sqs');
-      inst.sqs.should.be.an.Object;
-      inst.sqs.config.region.should.equal('us-east-1');
-    });
+      })
+      inst.should.have.property('sqs')
+      inst.sqs.should.be.an.Object
+      inst.sqs.config.region.should.equal('us-east-1')
+    })
     it('retrieves the queueUrl when a queueName is supplied', (done) => {
       AWS.SQS = class SQS {
         getQueueUrl(params, cb) {
-          params.QueueName.should.equal('foo');
-          setImmediate(cb.bind(null, null, { QueueUrl: 'fooUrl' }));
+          params.QueueName.should.equal('foo')
+          setImmediate(cb.bind(null, null, { QueueUrl: 'fooUrl' }))
         }
-      };
-      inst = new Squiss({ queueName: 'foo' });
-      inst.on('ready', done);
-    });
+      }
+      inst = new Squiss({ queueName: 'foo' })
+      inst.on('ready', done)
+    })
     it('retrieves the queueUrl from a different account', (done) => {
       AWS.SQS = class SQS {
         getQueueUrl(params, cb) {
-          params.QueueName.should.equal('foo');
-          params.QueueOwnerAWSAccountId.should.equal('bar');
-          setImmediate(cb.bind(null, null, { QueueUrl: 'fooUrl' }));
+          params.QueueName.should.equal('foo')
+          params.QueueOwnerAWSAccountId.should.equal('bar')
+          setImmediate(cb.bind(null, null, { QueueUrl: 'fooUrl' }))
         }
-      };
+      }
       inst = new Squiss({
         queueName: 'foo',
         accountNumber: 'bar'
-      });
-      inst.on('ready', done);
-    });
-  });
+      })
+      inst.on('ready', done)
+    })
+  })
   describe('Receiving', () => {
     it('waits to run until a queueUrl is retrieved', (done) => {
       AWS.SQS = class SQS {
         getQueueUrl(params, cb) {
-          setImmediate(cb.bind(null, null, { QueueUrl: 'fooUrl' }));
+          setImmediate(cb.bind(null, null, { QueueUrl: 'fooUrl' }))
         }
-      };
-      inst = new Squiss({ queueName: 'foo' });
-      inst.sqs = new SQSStub(1);
-      inst.start();
+      }
+      inst = new Squiss({ queueName: 'foo' })
+      inst.sqs = new SQSStub(1)
+      inst.start()
       inst.on('ready', () => {
-        inst.on('message', () => done());
-      });
-    });
+        inst.on('message', () => done())
+      })
+    })
     it('reports the appropriate "running" status', () => {
-      inst = new Squiss({ queueUrl: 'foo' });
-      inst._getBatch = () => {};
-      inst.running.should.be.false;
-      inst.start();
-      inst.running.should.be.true;
-    });
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst._getBatch = () => {}
+      inst.running.should.be.false
+      inst.start()
+      inst.running.should.be.true
+    })
     it('treats start() as idempotent', () => {
-      inst = new Squiss({ queueUrl: 'foo' });
-      inst._getBatch = () => {};
-      inst.running.should.be.false;
-      inst.start();
-      inst.start();
-      inst.running.should.be.true;
-    });
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst._getBatch = () => {}
+      inst.running.should.be.false
+      inst.start()
+      inst.start()
+      inst.running.should.be.true
+    })
     it('receives a batch of messages under the max', (done) => {
-      let msgs = 0;
-      inst = new Squiss({ queueUrl: 'foo' });
-      inst.sqs = new SQSStub(5);
-      inst.start();
-      inst.on('message', () => msgs++);
+      let msgs = 0
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst.sqs = new SQSStub(5)
+      inst.start()
+      inst.on('message', () => msgs++)
       setImmediate(() => {
-        msgs.should.equal(5);
-        done();
-      });
-    });
+        msgs.should.equal(5)
+        done()
+      })
+    })
     it('receives batches of messages', (done) => {
-      let msgs = 0;
-      inst = new Squiss({ queueUrl: 'foo' });
-      inst.sqs = new SQSStub(15);
-      inst.start();
-      inst.on('message', () => msgs++);
+      let msgs = 0
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst.sqs = new SQSStub(15)
+      inst.start()
+      inst.on('message', () => msgs++)
       setImmediate(() => {
-        msgs.should.equal(10);
+        msgs.should.equal(10)
         setImmediate(() => {
-          msgs.should.equal(15);
-          done();
-        });
-      });
-    });
+          msgs.should.equal(15)
+          done()
+        })
+      })
+    })
     it('receives batches of messages when maxInflight = receiveBatchSize', (done) => {
-      let msgs = 0;
-      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 10, receiveBatchSize: 10 });
-      inst.sqs = new SQSStub(15);
-      inst.start();
+      let msgs = 0
+      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 10, receiveBatchSize: 10 })
+      inst.sqs = new SQSStub(15)
+      inst.start()
       inst.on('message', (m) => {
-        msgs++;
-        m.del();
-      });
+        msgs++
+        m.del()
+      })
       setImmediate(() => {
-        msgs.should.equal(10);
+        msgs.should.equal(10)
         setImmediate(() => {
-          msgs.should.equal(15);
-          done();
-        });
-      });
-    });
+          msgs.should.equal(15)
+          done()
+        })
+      })
+    })
     it('receives no messages', (done) => {
-      let msgs = 0;
-      inst = new Squiss({ queueUrl: 'foo' });
-      inst.sqs = new SQSStub(0, 0);
-      inst.start();
-      inst.on('message', () => msgs++);
+      let msgs = 0
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst.sqs = new SQSStub(0, 0)
+      inst.start()
+      inst.on('message', () => msgs++)
       setTimeout(() => {
-        msgs.should.equal(0);
-        done();
-      }, 5);
-    });
+        msgs.should.equal(0)
+        done()
+      }, 5)
+    })
     it('emits queueEmpty event with no messages', (done) => {
-      let msgs = 0;
-      inst = new Squiss({ queueUrl: 'foo' });
-      inst.sqs = new SQSStub(0, 0);
-      inst.start();
-      inst.on('message', () => msgs++);
+      let msgs = 0
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst.sqs = new SQSStub(0, 0)
+      inst.start()
+      inst.on('message', () => msgs++)
       inst.on('queueEmpty', () => {
-        msgs.should.equal(0);
-        inst.stop();
-        done();
-      });
-    });
+        msgs.should.equal(0)
+        inst.stop()
+        done()
+      })
+    })
     it('observes the maxInFlight cap', (done) => {
-      let msgs = 0;
-      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 10 });
-      inst.sqs = new SQSStub(15);
-      inst.start();
-      inst.on('message', () => msgs++);
+      let msgs = 0
+      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 10 })
+      inst.sqs = new SQSStub(15)
+      inst.start()
+      inst.on('message', () => msgs++)
       setImmediate(() => {
-        msgs.should.equal(10);
+        msgs.should.equal(10)
         setImmediate(() => {
-          msgs.should.equal(10);
-          done();
-        });
-      });
-    });
+          msgs.should.equal(10)
+          done()
+        })
+      })
+    })
     it('respects maxInFlight as 0 (no cap)', (done) => {
-      let msgs = 0;
-      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 0 });
-      inst.sqs = new SQSStub(35);
-      inst.start();
-      inst.on('message', () => msgs++);
+      let msgs = 0
+      inst = new Squiss({ queueUrl: 'foo', maxInFlight: 0 })
+      inst.sqs = new SQSStub(35)
+      inst.start()
+      inst.on('message', () => msgs++)
       setImmediate(() => {
-        msgs.should.equal(10);
+        msgs.should.equal(10)
         setImmediate(() => {
-          msgs.should.equal(20);
+          msgs.should.equal(20)
           setImmediate(() => {
-            msgs.should.equal(30);
+            msgs.should.equal(30)
             setImmediate(() => {
-              msgs.should.equal(35);
-              done();
-            });
-          });
-        });
-      });
-    });
+              msgs.should.equal(35)
+              done()
+            })
+          })
+        })
+      })
+    })
     it('reports the correct number of inFlight messages', (done) => {
-      let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 });
-      inst.sqs = new SQSStub(5);
-      inst.start();
-      inst.on('message', (msg) => msgs.push(msg));
+      let msgs = []
+      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 })
+      inst.sqs = new SQSStub(5)
+      inst.start()
+      inst.on('message', (msg) => msgs.push(msg))
       setImmediate(() => {
-        inst.inFlight.should.equal(5);
-        inst.deleteMessage(msgs.pop());
-        inst.handledMessage();
+        inst.inFlight.should.equal(5)
+        inst.deleteMessage(msgs.pop())
+        inst.handledMessage()
         setImmediate(() => {
-          inst.inFlight.should.equal(3);
-          done();
-        });
-      });
-    });
-  });
+          inst.inFlight.should.equal(3)
+          done()
+        })
+      })
+    })
+  })
   describe('Deleting', () => {
     it('deletes messages using internal API', (done) => {
-      let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 });
-      inst.sqs = new SQSStub(5);
-      sinon.spy(inst.sqs, 'deleteMessageBatch');
-      inst.start();
-      inst.on('message', (msg) => msgs.push(msg));
+      let msgs = []
+      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 })
+      inst.sqs = new SQSStub(5)
+      sinon.spy(inst.sqs, 'deleteMessageBatch')
+      inst.start()
+      inst.on('message', (msg) => msgs.push(msg))
       setImmediate(() => {
-        msgs.should.have.length(5);
-        inst.deleteMessage(msgs.pop());
+        msgs.should.have.length(5)
+        inst.deleteMessage(msgs.pop())
         setTimeout(() => {
-          inst.sqs.deleteMessageBatch.calledOnce.should.be.true;
-          done();
-        }, 10);
-      });
-    });
+          inst.sqs.deleteMessageBatch.calledOnce.should.be.true
+          done()
+        }, 10)
+      })
+    })
     it('deletes messages using Message API', (done) => {
-      let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 });
-      inst.sqs = new SQSStub(5);
-      sinon.spy(inst.sqs, 'deleteMessageBatch');
-      inst.start();
-      inst.on('message', (msg) => msgs.push(msg));
+      let msgs = []
+      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 1 })
+      inst.sqs = new SQSStub(5)
+      sinon.spy(inst.sqs, 'deleteMessageBatch')
+      inst.start()
+      inst.on('message', (msg) => msgs.push(msg))
       setImmediate(() => {
-        msgs.should.have.length(5);
-        msgs.pop().del();
+        msgs.should.have.length(5)
+        msgs.pop().del()
         setTimeout(() => {
-          inst.sqs.deleteMessageBatch.calledOnce.should.be.true;
-          done();
-        }, 10);
-      });
-    });
+          inst.sqs.deleteMessageBatch.calledOnce.should.be.true
+          done()
+        }, 10)
+      })
+    })
     it('deletes messages in batches', (done) => {
-      let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 10 });
-      inst.sqs = new SQSStub(15);
-      sinon.spy(inst.sqs, 'deleteMessageBatch');
-      inst.start();
-      inst.on('message', (msg) => msgs.push(msg));
+      let msgs = []
+      inst = new Squiss({ queueUrl: 'foo', deleteWaitMs: 10 })
+      inst.sqs = new SQSStub(15)
+      sinon.spy(inst.sqs, 'deleteMessageBatch')
+      inst.start()
+      inst.on('message', (msg) => msgs.push(msg))
       setTimeout(() => {
-        inst.stop();
-        msgs.forEach((msg) => msg.del());
-        inst.sqs.deleteMessageBatch.calledOnce.should.be.true;
+        inst.stop()
+        msgs.forEach((msg) => msg.del())
+        inst.sqs.deleteMessageBatch.calledOnce.should.be.true
         setTimeout(() => {
-          inst.sqs.deleteMessageBatch.calledTwice.should.be.true;
-          done();
-        }, 20);
-      }, 5);
-    });
+          inst.sqs.deleteMessageBatch.calledTwice.should.be.true
+          done()
+        }, 20)
+      }, 5)
+    })
     it('deletes immediately with batch size=1', (done) => {
-      let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 1 });
-      inst.sqs = new SQSStub(1);
-      sinon.spy(inst.sqs, 'deleteMessageBatch');
-      inst.start();
-      inst.on('message', (msg) => msgs.push(msg));
+      let msgs = []
+      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 1 })
+      inst.sqs = new SQSStub(1)
+      sinon.spy(inst.sqs, 'deleteMessageBatch')
+      inst.start()
+      inst.on('message', (msg) => msgs.push(msg))
       setImmediate(() => {
-        inst.stop();
-        msgs[0].del();
-        inst.sqs.deleteMessageBatch.calledOnce.should.be.true;
-        done();
-      });
-    });
+        inst.stop()
+        msgs[0].del()
+        inst.sqs.deleteMessageBatch.calledOnce.should.be.true
+        done()
+      })
+    })
     it('delWaitTime Timeout should be cleared after timeout runs', (done) => {
-      let msgs = [];
-      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 10, deleteWaitMs: 10});
-      inst.sqs = new SQSStub(2);
-      sinon.spy(inst, '_deleteMessages');
-      inst.start();
-      inst.on('message', (msg) => msgs.push(msg));
+      let msgs = []
+      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 10, deleteWaitMs: 10})
+      inst.sqs = new SQSStub(2)
+      sinon.spy(inst, '_deleteMessages')
+      inst.start()
+      inst.on('message', (msg) => msgs.push(msg))
       setTimeout(() => {
-        inst.stop();
-        msgs[0].del();
+        inst.stop()
+        msgs[0].del()
         setTimeout(() => {
-          inst._deleteMessages.calledOnce.should.be.true;
-          msgs[1].del();
+          inst._deleteMessages.calledOnce.should.be.true
+          msgs[1].del()
           setTimeout(() => {
-            inst._deleteMessages.calledTwice.should.be.true;
-            done();
-          }, 20);
-        }, 20);
-      }, 5);
-    });
-  });
+            inst._deleteMessages.calledTwice.should.be.true
+            done()
+          }, 20)
+        }, 20)
+      }, 5)
+    })
+  })
   describe('Failures', () => {
     it('emits delError when a message fails to delete', (done) => {
-      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 1 });
-      inst.sqs = new SQSStub(1);
+      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 1 })
+      inst.sqs = new SQSStub(1)
       inst.on('delError', (fail) => {
-        should.exist(fail);
-        fail.should.be.an.Object;
-        done();
-      });
+        should.exist(fail)
+        fail.should.be.an.Object
+        done()
+      })
       inst.deleteMessage({
         raw: {
           MessageId: 'foo',
           ReceiptHandle: 'bar'
         }
-      });
-    });
+      })
+    })
     it('emits error when delete call fails', (done) => {
-      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 1 });
-      inst.sqs = new SQSStub(1);
+      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 1 })
+      inst.sqs = new SQSStub(1)
       inst.sqs.deleteMessageBatch = (params, cb) => {
-        cb(new Error('test'));
-      };
+        cb(new Error('test'))
+      }
       inst.on('error', (err) => {
-        should.exist(err);
-        err.should.be.an.Error;
-        done();
-      });
+        should.exist(err)
+        err.should.be.an.Error
+        done()
+      })
       inst.deleteMessage({
         raw: {
           MessageId: 'foo',
           ReceiptHandle: 'bar'
         }
-      });
-    });
+      })
+    })
     it('emits error when receive call fails', (done) => {
-      inst = new Squiss({ queueUrl: 'foo' });
-      inst.sqs = new SQSStub(1);
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst.sqs = new SQSStub(1)
       inst.sqs.receiveMessage = (params, cb) => {
-        cb(new Error('test'));
-      };
+        cb(new Error('test'))
+      }
       inst.on('error', (err) => {
-        should.exist(err);
-        err.should.be.an.Error;
-        done();
-      });
-      inst.start();
-    });
+        should.exist(err)
+        err.should.be.an.Error
+        done()
+      })
+      inst.start()
+    })
     it('attempts to repoll after a receive call fails', (done) => {
-      inst = new Squiss({ queueUrl: 'foo', receiveBatchSize: 1, pollRetryMs: 5});
-      inst.sqs = new SQSStub(2);
+      inst = new Squiss({ queueUrl: 'foo', receiveBatchSize: 1, pollRetryMs: 5})
+      inst.sqs = new SQSStub(2)
       sinon.stub(inst.sqs, 'receiveMessage', (params, cb) => {
-        cb(new Error('test'));
-        inst.sqs.receiveMessage.restore();
-      });
-      let msgs = 0;
-      let errs = 0;
-      inst.on('message', () => msgs++);
-      inst.on('error', () => errs++);
-      inst.start();
+        cb(new Error('test'))
+        inst.sqs.receiveMessage.restore()
+      })
+      let msgs = 0
+      let errs = 0
+      inst.on('message', () => msgs++)
+      inst.on('error', () => errs++)
+      inst.start()
       setTimeout(() => {
-        errs.should.eql(1);
-        msgs.should.eql(2);
-        done();
-      }, 10);
-    });
+        errs.should.eql(1)
+        msgs.should.eql(2)
+        done()
+      }, 10)
+    })
     it('emits error when GetQueueURL call fails', (done) => {
       AWS.SQS = class SQS {
         getQueueUrl(params, cb) {
-          setImmediate(cb.bind(null, new Error('test')));
+          setImmediate(cb.bind(null, new Error('test')))
         }
-      };
-      inst = new Squiss({ queueName: 'foo' });
+      }
+      inst = new Squiss({ queueName: 'foo' })
       inst.on('error', (err) => {
-        should.exist(err);
-        err.should.be.an.Error;
-        done();
-      });
-    });
-  });
+        should.exist(err)
+        err.should.be.an.Error
+        done()
+      })
+    })
+  })
   describe('Testing', () => {
     it('allows queue URLs to be corrected to the endpoint hostname', (done) => {
-      AWS.SQS = function() { return new SQSStub(1); };
-      inst = new Squiss({ queueName: 'foo', correctQueueUrl: true });
-      inst.sqs = new SQSStub(1);
+      AWS.SQS = function() { return new SQSStub(1) }
+      inst = new Squiss({ queueName: 'foo', correctQueueUrl: true })
+      inst.sqs = new SQSStub(1)
       inst.on('ready', () => {
-        inst._queueUrl.should.equal('http://foo.bar/queues/foo');
-        done();
-      });
-    });
-  });
-});
+        inst._queueUrl.should.equal('http://foo.bar/queues/foo')
+        done()
+      })
+    })
+  })
+})

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -24,7 +24,7 @@ describe('index', () => {
       inst = new Squiss({
         queueUrl: 'foo',
         unwrapSns: true,
-        visibilityTimeout: 10
+        visibilityTimeoutSecs: 10
       })
       should.exist(inst)
     })

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -666,13 +666,4 @@ describe('index', () => {
       })
     })
   })
-  describe('Deprecations', () => {
-    it('writes to stderr when visibilityTimeout is used', () => {
-      const stub = sinon.stub(process.stderr, 'write', () => {})
-      inst = new Squiss({ queueUrl: 'foo', visibilityTimeout: 30})
-      stub.should.be.calledOnce
-      stub.restore()
-      inst._opts.should.have.property('visibilityTimeoutSecs').equal(30)
-    })
-  })
 })

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -344,4 +344,70 @@ describe('index', () => {
       })
     })
   })
+  describe('createQueue', () => {
+    it('rejects if Squiss was instantiated without queueName', () => {
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst.sqs = new SQSStub(1)
+      return inst.createQueue().should.be.rejected
+    })
+    it('calls SQS SDK createQueue method with default attributes', () => {
+      inst = new Squiss({ queueName: 'foo' })
+      inst.sqs = new SQSStub(1)
+      const spy = sinon.spy(inst.sqs, 'createQueue')
+      return inst.createQueue().then((queueUrl) => {
+        queueUrl.should.be.a.string
+        spy.should.be.calledOnce
+        spy.should.be.calledWith({
+          QueueName: 'foo',
+          Attributes: {
+            ReceiveMessageWaitTimeSeconds: '20',
+            DelaySeconds: '0',
+            MaximumMessageSize: '262144',
+            MessageRetentionPeriod: '345600',
+            VisibilityTimeout: '30'
+          }
+        })
+      })
+    })
+    it('calls SQS SDK createQueue method with custom attributes', () => {
+      inst = new Squiss({
+        queueName: 'foo',
+        receiveWaitTimeSecs: 10,
+        delaySecs: 300,
+        maxMessageBytes: 100,
+        messageRetentionSecs: 60,
+        visibilityTimeoutSecs: 10,
+        queuePolicy: {foo: 'bar'}
+      })
+      inst.sqs = new SQSStub(1)
+      const spy = sinon.spy(inst.sqs, 'createQueue')
+      return inst.createQueue().then((queueUrl) => {
+        queueUrl.should.be.a.string
+        spy.should.be.calledOnce
+        spy.should.be.calledWith({
+          QueueName: 'foo',
+          Attributes: {
+            ReceiveMessageWaitTimeSeconds: '10',
+            DelaySeconds: '300',
+            MaximumMessageSize: '100',
+            MessageRetentionPeriod: '60',
+            VisibilityTimeout: '10',
+            Policy: {foo: 'bar'}
+          }
+        })
+      })
+    })
+  })
+  describe('deleteQueue', () => {
+    it('calls SQS SDK deleteQueue method with queue URL', () => {
+      inst = new Squiss({ queueUrl: 'foo' })
+      inst.sqs = new SQSStub(1)
+      const spy = sinon.spy(inst.sqs, 'deleteQueue')
+      return inst.deleteQueue().then((res) => {
+        res.should.be.an.object
+        spy.should.be.calledOnce
+        spy.should.be.calledWith({ QueueUrl: 'foo' })
+      })
+    })
+  })
 })

--- a/test/stubs/SQSStub.js
+++ b/test/stubs/SQSStub.js
@@ -11,7 +11,7 @@ class SQSStub extends EventEmitter {
     super()
     this.msgs = []
     this.timeout = timeout === undefined ? 20 : timeout
-    this.msgCount = msgCount
+    this.msgCount = msgCount || 0
     this.config = {
       region: 'us-east-1',
       endpoint: 'http://foo.bar'

--- a/test/stubs/SQSStub.js
+++ b/test/stubs/SQSStub.js
@@ -81,7 +81,7 @@ class SQSStub extends EventEmitter {
         }
         const onNewMessage = () => {
           removeListeners()
-          resolve({Messages: [this.msgs.shift()]})
+          resolve(this.receiveMessage().promise())
         }
         removeListeners = () => {
           clearTimeout(timeout)

--- a/test/stubs/SQSStub.js
+++ b/test/stubs/SQSStub.js
@@ -79,9 +79,9 @@ class SQSStub extends EventEmitter {
           err.time = new Date()
           reject(err)
         }
-        const onNewMessage = (msg) => {
+        const onNewMessage = () => {
           removeListeners()
-          resolve({Messages: [msg]})
+          resolve({Messages: [this.msgs.shift()]})
         }
         removeListeners = () => {
           clearTimeout(timeout)
@@ -138,7 +138,7 @@ class SQSStub extends EventEmitter {
       ReceiptHandle: `${id}`,
       Body: body || `{"num": ${id}}`
     })
-    this.emit('newMessage', this.msgs[this.msgs.length - 1])
+    this.emit('newMessage')
   }
 
   _makeReq(func) {

--- a/test/stubs/SQSStub.js
+++ b/test/stubs/SQSStub.js
@@ -1,22 +1,24 @@
 /*
- * Copyright (c) 2015 TechnologyAdvice
+ * Copyright (c) 2015-2016 TechnologyAdvice
  */
+
+'use strict'
 
 class SQSStub {
   constructor(msgCount, timeout) {
-    this.msgs = [];
-    this.timeout = timeout === undefined ? 20 : timeout;
-    this.msgCount = msgCount;
+    this.msgs = []
+    this.timeout = timeout === undefined ? 20 : timeout
+    this.msgCount = msgCount
     this.config = {
       region: 'us-east-1',
       endpoint: 'http://foo.bar'
-    };
+    }
     for (let i = 0; i < msgCount; i++) {
       this.msgs.push({
         MessageId: `id_${i}`,
         ReceiptHandle: `${i}`,
         body: `{"num": ${i}}`
-      });
+      })
     }
   }
 
@@ -24,36 +26,36 @@ class SQSStub {
     const res = {
       Successful: [],
       Failed: []
-    };
+    }
     params.Entries.forEach((entry) => {
       if (parseInt(entry.ReceiptHandle, 10) < this.msgCount) {
-        res.Successful.push({Id: entry.Id});
+        res.Successful.push({Id: entry.Id})
       } else {
         res.Failed.push({
           Id: entry.Id,
           SenderFault: true,
           Code: '404',
           Message: 'Does not exist'
-        });
+        })
       }
-    });
-    setImmediate(cb.bind(null, null, res));
+    })
+    setImmediate(cb.bind(null, null, res))
   }
 
   getQueueUrl(params, cb) {
     setImmediate(() => {
       cb(null, {
         QueueUrl: `http://localhost:9324/queues/${params.QueueName}`
-      });
-    });
+      })
+    })
   }
 
   receiveMessage(query, cb) {
-    const msgs = this.msgs.splice(0, query.MaxNumberOfMessages);
-    const done = cb.bind(null, null, msgs.length ? {Messages: msgs} : {});
-    if (msgs.length) setImmediate(done);
-    else setTimeout(done, this.timeout * 1000);
+    const msgs = this.msgs.splice(0, query.MaxNumberOfMessages)
+    const done = cb.bind(null, null, msgs.length ? {Messages: msgs} : {})
+    if (msgs.length) setImmediate(done)
+    else setTimeout(done, this.timeout * 1000)
   }
 }
 
-export default SQSStub;
+module.exports = SQSStub

--- a/test/stubs/SQSStub.js
+++ b/test/stubs/SQSStub.js
@@ -14,11 +14,7 @@ class SQSStub {
       endpoint: 'http://foo.bar'
     }
     for (let i = 0; i < msgCount; i++) {
-      this.msgs.push({
-        MessageId: `id_${i}`,
-        ReceiptHandle: `${i}`,
-        body: `{"num": ${i}}`
-      })
+      this._addMessage(i)
     }
   }
 
@@ -76,7 +72,8 @@ class SQSStub {
     })
   }
 
-  sendMessage() {
+  sendMessage(params) {
+    this._addMessage(params.QueueUrl, params.MessageBody)
     return this._makeReq(() => {
       return Promise.resolve({
         MessageId: 'd2206b43-df52-5161-a8e8-24dc83737962',
@@ -92,7 +89,8 @@ class SQSStub {
       Failed: []
     }
     params.Entries.forEach((entry, idx) => {
-      if (entry.MessageBody) {
+      if (entry.MessageBody !== 'FAIL') {
+        this._addMessage(entry.Id, entry.MessageBody)
         res.Successful.push({
           Id: entry.Id,
           MessageId: idx.toString(),
@@ -109,6 +107,14 @@ class SQSStub {
       }
     })
     return this._makeReq(() => Promise.resolve(res))
+  }
+
+  _addMessage(id, body) {
+    this.msgs.push({
+      MessageId: `id_${id}`,
+      ReceiptHandle: `${id}`,
+      Body: body || `{"num": ${id}}`
+    })
   }
 
   _makeAbort(reject, timeout) {

--- a/test/stubs/SQSStub.js
+++ b/test/stubs/SQSStub.js
@@ -22,6 +22,10 @@ class SQSStub {
     }
   }
 
+  createQueue(params) {
+    return this.getQueueUrl(params)
+  }
+
   deleteMessageBatch(params) {
     return this._makeReq(() => {
       const res = {
@@ -41,6 +45,12 @@ class SQSStub {
         }
       })
       return Promise.resolve(res)
+    })
+  }
+
+  deleteQueue() {
+    return this._makeReq(() => {
+      return Promise.resolve({ ResponseMetadata: { RequestId: 'd2206b43-df52-5161-a8e8-24dc83737962' } })
     })
   }
 
@@ -64,6 +74,41 @@ class SQSStub {
         return undefined
       })
     })
+  }
+
+  sendMessage() {
+    return this._makeReq(() => {
+      return Promise.resolve({
+        MessageId: 'd2206b43-df52-5161-a8e8-24dc83737962',
+        MD5OfMessageAttributes: 'deadbeefdeadbeefdeadbeefdeadbeef',
+        MD5OfMessageBody: 'deadbeefdeadbeefdeadbeefdeadbeef'
+      })
+    })
+  }
+
+  sendMessageBatch(params) {
+    const res = {
+      Successful: [],
+      Failed: []
+    }
+    params.Entries.forEach((entry, idx) => {
+      if (entry.MessageBody) {
+        res.Successful.push({
+          Id: entry.Id,
+          MessageId: idx.toString(),
+          MD5OfMessageAttributes: 'deadbeefdeadbeefdeadbeefdeadbeef',
+          MD5OfMessageBody: 'deadbeefdeadbeefdeadbeefdeadbeef'
+        })
+      } else {
+        res.Failed.push({
+          Id: entry.Id,
+          SenderFault: true,
+          Code: 'Message is empty',
+          Message: ''
+        })
+      }
+    })
+    return this._makeReq(() => Promise.resolve(res))
   }
 
   _makeAbort(reject, timeout) {


### PR DESCRIPTION
See the CHANGELOG.md for actual insights into what's different -- the diff is near-worthless because the semis-removal is part of this PR. Much of the code got rewritten anyway.

Test coverage is 100% and passing, and I've used this version lightly in production requests as well to great success.

Only three breaking changes from 0.7:
- Node 0.12 is no longer supported
- stop() now halts in-progress receiveMessage requests (@stephen-ta will enjoy that)
- I've renamed `opts.visibilityTimeout` to `opts.visibilityTimeoutSecs` for consistent naming with the other options. The old version still works, but is deprecated with a message to stderr. Really unhappy with the code annoyances that go along with supporting this change, but I couldn't stomach visibilityTimeout being the only option that didn't have the units at the end.