### PR TITLE
Add option to pass in an SQS constructor upon Squiss instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Use the following options to point Squiss at the right queue:
 - **opts.correctQueueUrl** _Default false._ Changes the protocol, host, and port of the queue URL to match the configured SQS endpoint (see opts.awsConfig), applicable only if opts.queueName is specified. This can be useful for testing against a local SQS service, such as ElasticMQ.
 
 Squiss's defaults are great out of the box for most use cases, but you can use the below to fine-tune your Squiss experience:
+- **opts.SQS** _Default AWS.SQS_ An SQS constructor function to use rather than the default one provided by AWS.SQS
 - **opts.activePollIntervalMs** _Default 0._ The number of milliseconds to wait between requesting batches of messages when the queue is not empty, and the maxInFlight cap has not been hit. For most use cases, it's better to leave this at 0 and let Squiss manage the active polling frequency according to maxInFlight.
 - **opts.bodyFormat** _Default "plain"._ The format of the incoming message. Set to "json" to automatically call `JSON.parse()` on each incoming message.
 - **opts.deleteBatchSize** _Default 10._ The number of messages to delete at one time. Squiss will trigger a batch delete when this limit is reached, or when deleteWaitMs milliseconds have passed since the first queued delete in the batch; whichever comes first. Set to 1 to make all deletes immediate. Maximum 10.

--- a/package.json
+++ b/package.json
@@ -42,9 +42,9 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "delay": "^1.3.1",
-    "eslint": "^2.8.0",
+    "eslint": "^3.7.1",
     "istanbul": "^0.4.3",
-    "mocha": "^2.4.5",
+    "mocha": "^3.1.2",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0"
   }

--- a/src/index.js
+++ b/src/index.js
@@ -44,6 +44,7 @@ class Squiss extends EventEmitter {
   /**
    * Creates a new Squiss object.
    * @param {Object} opts A map of options to configure this instance
+   * @param {Function} [opts.SQS] An SQS constructor function to use rather than the default one provided by SQS
    * @param {Object} [opts.awsConfig] An object mapping to pass to the SQS constructor, configuring the
    *    aws-sdk library. This is commonly used to set the AWS region, or the user credentials. See
    *    http://docs.aws.amazon.com/AWSJavaScriptSDK/guide/node-configuring.html
@@ -100,7 +101,7 @@ class Squiss extends EventEmitter {
   constructor(opts) {
     super()
     opts = opts || {}
-    this.sqs = new AWS.SQS(opts.awsConfig)
+    this.sqs = opts.SQS ? new opts.SQS(opts.awsConfig) : new AWS.SQS(opts.awsConfig)
     this._opts = {}
     Object.assign(this._opts, optDefaults, opts)
     this._opts.deleteBatchSize = Math.min(this._opts.deleteBatchSize, 10)

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -51,6 +51,16 @@ describe('index', () => {
       inst.sqs.should.be.an.Object
       inst.sqs.config.region.should.equal('us-east-1')
     })
+    it('accepts an sqs function for instantiation if one is provided', () => {
+      const spy = sinon.spy()
+      inst = new Squiss({
+        queueUrl: 'foo',
+        SQS: spy
+      })
+      inst.should.have.property('sqs')
+      inst.sqs.should.be.an.Object
+      spy.should.be.calledOnce
+    })
   })
   describe('Receiving', () => {
     it('reports the appropriate "running" status', () => {


### PR DESCRIPTION
Thanks for all of your work on Squiss! It's worked well for me. This is a small change that allows a user to pass in an SQS constructor upon Squiss instantiation, which will be used rather than the one provided by the SDK.

Although the use case is likely rare, it allows Squiss to function in an environment where SQS should not (or cannot) be used (such as local development of an application that uses SQS for message transport).
