### PR TITLE
Feat: Receive message attributes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   },
   "homepage": "https://github.com/TechnologyAdvice/Squiss#readme",
   "dependencies": {
-    "aws-sdk": "^2.10.0"
+    "aws-sdk": "^2.10.0",
+    "lodash.reduce": "4.6.0"
   },
   "devDependencies": {
     "chai": "^3.5.0",

--- a/src/index.js
+++ b/src/index.js
@@ -407,7 +407,8 @@ class Squiss extends EventEmitter {
     const params = {
       QueueUrl: queueUrl,
       MaxNumberOfMessages: this._opts.receiveBatchSize,
-      WaitTimeSeconds: this._opts.receiveWaitTimeSecs
+      WaitTimeSeconds: this._opts.receiveWaitTimeSecs,
+      MessageAttributeNames: ['All']
     }
     if (this._opts.visibilityTimeoutSecs !== undefined) {
       params.VisibilityTimeout = this._opts.visibilityTimeoutSecs

--- a/test/src/Message.spec.js
+++ b/test/src/Message.spec.js
@@ -11,7 +11,25 @@ function getSQSMsg(body) {
     MessageId: 'msgId',
     ReceiptHandle: 'handle',
     MD5OfBody: 'abcdeabcdeabcdeabcdeabcdeabcde12',
-    Body: body
+    Body: body,
+    MessageAttributes: {
+      SomeNumber: {
+        DataType: 'Number',
+        StringValue: '1'
+      },
+      SomeString: {
+        DataType: 'String',
+        StringValue: 's'
+      },
+      SomeBinary: {
+        DataType: 'Binary',
+        BinaryValue: new Buffer(['s'])
+      },
+      SomeCustomBinary: {
+        DataType: 'CustomBinary',
+        BinaryValue: new Buffer(['c'])
+      }
+    }
   }
 }
 
@@ -49,6 +67,12 @@ describe('Message', () => {
     msg.body.should.be.an('object')
     msg.body.should.have.property('Message').equal('foo')
     msg.body.should.have.property('bar').equal('baz')
+    msg.attributes.should.be.eql({
+      SomeNumber: 1,
+      SomeString: 's',
+      SomeBinary: new Buffer(['s']),
+      SomeCustomBinary: new Buffer(['c'])
+    })
   })
   it('calls Squiss.deleteMessage on delete', (done) => {
     const msg = new Message({

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -226,7 +226,8 @@ describe('index', () => {
           QueueUrl: 'foo',
           MaxNumberOfMessages: 10,
           WaitTimeSeconds: 20,
-          VisibilityTimeout: 10
+          VisibilityTimeout: 10,
+          MessageAttributeNames: ['All']
         })
       })
     })


### PR DESCRIPTION
I wonder if I should write a parser...
https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#receiveMessage-property
```js
{
      MessageAttributes: {
       "City": {
         DataType: "String", 
         StringValue: "Any City"
        }, 
       "PostalCode": {
         DataType: "Number", 
         StringValue: "123"
        }
      }
}
```
would become
```js
// message.attributes
{
  City: 'Any City',
  PostalCode: 123
}
```