### PR TITLE
Allow passing in already-instantiated SQS client

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -101,7 +101,15 @@ class Squiss extends EventEmitter {
   constructor(opts) {
     super()
     opts = opts || {}
-    this.sqs = opts.SQS ? new opts.SQS(opts.awsConfig) : new AWS.SQS(opts.awsConfig)
+    if (opts.SQS) {
+      if (typeof opts.SQS === 'function') {
+        this.sqs = new opts.SQS(opts.awsConfig)
+      } else {
+        this.sqs = opts.SQS
+      }
+    } else {
+      this.sqs = new AWS.SQS(opts.awsConfig)
+    }
     this._opts = {}
     Object.assign(this._opts, optDefaults, opts)
     this._opts.deleteBatchSize = Math.min(this._opts.deleteBatchSize, 10)

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -61,6 +61,14 @@ describe('index', () => {
       inst.sqs.should.be.an('object')
       spy.should.be.calledOnce()
     })
+    it('accepts an instance of sqs client if one is provided', () => {
+      inst = new Squiss({
+        queueUrl: 'foo',
+        SQS: {}
+      })
+      inst.should.have.property('sqs')
+      inst.sqs.should.be.an('object')
+    })
   })
   describe('Receiving', () => {
     it('reports the appropriate "running" status', () => {


### PR DESCRIPTION
@TomFrost upon further consideration, I think the option to pass in an SQS client that has already been instantiated will be quite useful (in fact, I have a use for it already).

I figured just checking if the option passed in is a function or an object would be enough — but if you feel stronger validation is important, we could also check that if the option is an object, it also has the requisite methods attached to it.

Let me know what you think!