### PR TITLE
TimeoutExtender: Auto-extend the VisibilityTimeout of unhandled messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - The `getQueueVisibilityTimeout` function. Intuitively, this gets the queue's VisibilityTimeout. 
 
 ### Changed
-- BREAKING: The `deleteMessage` method new requires a Message object to be passed to it; not just the receiptHandle
-- BREAKING: The `releaseMessage` method new requires a Message object to be passed to it; not just the receiptHandle
+- BREAKING: The `deleteMessage` method now requires a Message object to be passed to it; not just the receiptHandle
+- BREAKING: The `releaseMessage` method now requires a Message object to be passed to it; not just the receiptHandle
 - BREAKING: The `handledMessage` method now requires a Message object to be passed to it
 - The `start()` function now returns a Promise that resolves when the poller has started
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Development]
-Nothing yet!
+### Added
+- The `deleted` event, fired when a message has been confirmed to be successfully deleted
+- The `delQueued` event, fired when a message deletion has been queued up for the next batch
+- The `handled` event, fired when a message has been handled by any means (kept, deleted, or released)
+- The `released` event, fired when a message has been confirmed to be successfully released back for immediate availability
+- The TimeoutExtender feature, which can automatically extend the VisibilityTimeout of any message that has not yet been handled. See README for details!
+- The `autoExtendTimeout` and `noExtensionsAfterSecs` options to support the TimeoutExtender feature
+- The `getQueueVisibilityTimeout` function. Intuitively, this gets the queue's VisibilityTimeout. 
+
+### Changed
+- BREAKING: The `deleteMessage` method new requires a Message object to be passed to it; not just the receiptHandle
+- BREAKING: The `releaseMessage` method new requires a Message object to be passed to it; not just the receiptHandle
+- BREAKING: The `handledMessage` method now requires a Message object to be passed to it
 
 ## [v1.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - BREAKING: The `deleteMessage` method new requires a Message object to be passed to it; not just the receiptHandle
 - BREAKING: The `releaseMessage` method new requires a Message object to be passed to it; not just the receiptHandle
 - BREAKING: The `handledMessage` method now requires a Message object to be passed to it
+- The `start()` function now returns a Promise that resolves when the poller has started
 
 ## [v1.1.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,10 +57,10 @@ Are you using Squiss to create your queue, as well? Squiss will use `opts.receiv
 ### squiss.createQueue()
 Creates the configured queue! This returns a promise that resolves with the new queue's URL when it's complete. Note that this can only be called if you set `opts.queueName` when instantiating Squiss.
 
-### squiss.deleteMessage(Message|receiptHandle)
-Deletes a message, given either the full Message object sent to the `message` event, or the message's ReceiptHandle string. It's much easier to call `message.del()`, but if you need to do it right from the Squiss instance, this is how. Note that the message probably won't be deleted immediately -- it'll be queued for a batch delete. See the constructor notes for how to configure the specifics of that.
+### squiss.deleteMessage(Message)
+Deletes a message, given the full Message object sent to the `message` event. It's much easier to call `message.del()`, but if you need to do it right from the Squiss instance, this is how. Note that the message probably won't be deleted immediately -- it'll be queued for a batch delete. See the constructor notes for how to configure the specifics of that.
 
-### squiss.changeMessageVisibility(Message|receiptHandle, timeoutInSeconds)
+### squiss.changeMessageVisibility(Message, timeoutInSeconds)
 Changes the visibility timeout of a message, given either the full Squiss Message object or the receipt handle string.
 
 ### squiss.deleteQueue()
@@ -69,8 +69,11 @@ Deletes the configured queue, returning a promise that resolves on complete. Squ
 ### squiss.getQueueUrl()
 Returns a Promise that resolves with the URL of the configured queue, even if you only instantiated Squiss with a queueName. The correctQueueUrl setting applies to this result, if it was set.
 
-### squiss.handledMessage(Message|receiptHandle)
+### squiss.handledMessage(Message)
 Informs Squiss that you got a message that you're not planning on deleting, so that Squiss can decrement the number of "in-flight" messages. It's good practice to delete every message you process, but this can be useful in case of error. You can also call `message.keep()` on the message itself to invoke this.
+
+### squiss.releaseMessage(Message)
+Releases the given Message object back to the queue by setting its `VisibilityTimeout` to `0` and marking the message as handled internally. You can also call `message.release()` on the message itself to invoke this.
 
 ### squiss.sendMessage(message, delay, attributes)
 Sends an individual message to the configured queue, and returns a promise that resolves with AWS's official message metadata: an object containing `MessageId`, `MD5OfMessageAttributes`, and `MD5OfMessageBody`. Arguments:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Creates the configured queue! This returns a promise that resolves with the new 
 ### squiss.deleteMessage(Message)
 Deletes a message, given the full Message object sent to the `message` event. It's much easier to call `message.del()`, but if you need to do it right from the Squiss instance, this is how. Note that the message probably won't be deleted immediately -- it'll be queued for a batch delete. See the constructor notes for how to configure the specifics of that.
 
-### squiss.changeMessageVisibility(Message, timeoutInSeconds)
+### squiss.changeMessageVisibility(Message|receiptHandle, timeoutInSeconds)
 Changes the visibility timeout of a message, given either the full Squiss Message object or the receipt handle string.
 
 ### squiss.deleteQueue()

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For your convenience, Squiss provides direct access to the AWS SDK's SQS object,
 
 ## Events
 
-### deleted (Message)
+### deleted {Message}
 Emitted when a message is confirmed as being successfully deleted from the queue. The `handled` and `delQueued` events will also be fired for deleted messages, but that will come earlier, when the delete function is initially called.
 
 ### delError {Object}

--- a/README.md
+++ b/README.md
@@ -35,11 +35,13 @@ Use the following options to point Squiss at the right queue:
 Squiss's defaults are great out of the box for most use cases, but you can use the below to fine-tune your Squiss experience:
 - **opts.SQS** _Default AWS.SQS_ An SQS constructor function to use rather than the default one provided by AWS.SQS
 - **opts.activePollIntervalMs** _Default 0._ The number of milliseconds to wait between requesting batches of messages when the queue is not empty, and the maxInFlight cap has not been hit. For most use cases, it's better to leave this at 0 and let Squiss manage the active polling frequency according to maxInFlight.
+- **opts.autoExtendTimeout** _Default false._ If true, Squiss will automatically extend each message's VisibilityTimeout in the SQS queue until it's handled (by keeping, deleting, or releasing it). It will place the API call to extend the timeout 5 seconds in advance of the expiration, and will extend it by the number of seconds specified in `opts.visibilityTimeoutSecs`. If that's not specified, the VisibilityTimeout setting on the queue itself will be used.
 - **opts.bodyFormat** _Default "plain"._ The format of the incoming message. Set to "json" to automatically call `JSON.parse()` on each incoming message.
 - **opts.deleteBatchSize** _Default 10._ The number of messages to delete at one time. Squiss will trigger a batch delete when this limit is reached, or when deleteWaitMs milliseconds have passed since the first queued delete in the batch; whichever comes first. Set to 1 to make all deletes immediate. Maximum 10.
 - **opts.deleteWaitMs** _Default 2000._ The number of milliseconds to wait after the first queued message deletion before deleting the message(s) from SQS.
 - **opts.idlePollIntervalMs** _Default 0._ The number of milliseconds to wait before requesting a batch of messages when the queue was empty on the prior request.
 - **opts.maxInFlight** _Default 100._ The number of messages to keep "in-flight", or processing simultaneously. When this cap is reached, no more messages will be polled until currently in-flight messages are marked as deleted or handled. Setting this option to 0 will uncap your inFlight messages, pulling and delivering messages as long as there are messages to pull.
+- **opts.noExtensionsAfterSecs** _Default 0._ If set above 0 and `opts.autoExtendTimeout` is used, Squiss will stop auto-renewing a message's VisibilityTimeout when it reaches this age.
 - **opts.pollRetryMs** _Default 2000._ The number of milliseconds to wait before retrying when Squiss's call to retrieve messages from SQS fails.
 - **opts.receiveBatchSize** _Default 10._ The number of messages to receive at one time. Maximum 10 or maxInFlight, whichever is lower.
 - **opts.receiveWaitTimeSecs** _Default 20._ The number of seconds for which to hold open the SQS call to receive messages, when no message is currently available. It is recommended to set this high, as Squiss will re-open the receiveMessage HTTP request as soon as the last one ends. If this needs to be set low, consider setting activePollIntervalMs to space out calls to SQS. Maximum 20.
@@ -67,7 +69,7 @@ Deletes the configured queue, returning a promise that resolves on complete. Squ
 ### squiss.getQueueUrl()
 Returns a Promise that resolves with the URL of the configured queue, even if you only instantiated Squiss with a queueName. The correctQueueUrl setting applies to this result, if it was set.
 
-### squiss.handledMessage()
+### squiss.handledMessage(Message|receiptHandle)
 Informs Squiss that you got a message that you're not planning on deleting, so that Squiss can decrement the number of "in-flight" messages. It's good practice to delete every message you process, but this can be useful in case of error. You can also call `message.keep()` on the message itself to invoke this.
 
 ### squiss.sendMessage(message, delay, attributes)
@@ -114,9 +116,15 @@ For your convenience, Squiss provides direct access to the AWS SDK's SQS object,
 
 ## Events
 
+### deleted (Message)
+Emitted when a message is confirmed as being successfully deleted from the queue. The `handled` and `delQueued` events will also be fired for deleted messages, but that will come earlier, when the delete function is initially called.
+
 ### delError {Object}
 A `delError` is emitted when AWS reports that any of the deleted messages failed to actually delete. The
 object handed to you in this event is the AWS failure object described in the [SQS deleteMessageBatch documentation](http://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/SQS.html#getQueueUrl-property).
+
+### delQueued {Message}
+Emitted when a message is queued for deletion, even if delete queuing has been turned off.
 
 ### drained
 Emitted when the last in-flight message has been handled, and there are no more messages currently in flight.
@@ -127,8 +135,14 @@ If any of the AWS API calls outrightly fail, `error` is emitted. If you don't ha
 ### gotMessages {number}
 Emitted when Squiss asks SQS for a new batch of messages, and gets some (or one). Supplies the number of retrieved messages.
 
+### handled {Message}
+Emitted when a message is handled by any means: deleting, releasing, or calling `keep()` or `handledMessage()` on it. 
+
 ### queueEmpty
 Emitted when Squiss asks SQS for new messages, and doesn't get any.
+
+### released {Message}
+Emitted after `release()` or `releaseMessage` has been called and the VisibilityTimeout of a message has successfully been changed to `0`. The `handled` event will also be fired for released messages, but that will come earlier, when the release function is initially called. 
 
 ### aborted
 Emitted after a hard stop() if a request for new messages was already in progress.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ Emitted when a message is handled by any means: deleting, releasing, or calling 
 Emitted when Squiss asks SQS for new messages, and doesn't get any.
 
 ### released {Message}
-Emitted after `release()` or `releaseMessage` has been called and the VisibilityTimeout of a message has successfully been changed to `0`. The `handled` event will also be fired for released messages, but that will come earlier, when the release function is initially called. 
+Emitted after `release()` or `releaseMessage` has been called and the VisibilityTimeout of a message has successfully been changed to `0`. The `handled` event will also be fired for released messages, but that will come earlier, when the release function is initially called.
+ 
+### timeoutExtended {Message}
+Emitted when a message has had its timeout successfully extended by the `autoExtendTimeout` feature.
 
 ### aborted
 Emitted after a hard stop() if a request for new messages was already in progress.

--- a/src/TimeoutExtender.js
+++ b/src/TimeoutExtender.js
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2015-2017 TechnologyAdvice
+ */
+
+'use strict'
+
+/**
+ * The number of seconds to place the API call to change the VisibilityTimeout in advance
+ * of its expiration time.
+ * @type {number}
+ */
+const API_CALL_LEAD_SECS = 5
+
+/**
+ * Option defaults.
+ * @type {Object}
+ */
+const optDefaults = {
+  visibilityTimeoutSecs: 30,
+  noExtensionsAfterSecs: 0
+}
+
+/**
+ * The TimeoutExtender is a module that attaches itself to a Squiss instance via event
+ * listeners, and uses the instance's public API to automatically extend the
+ * VisibilityTimeout of the message until it is either handled (which includes actions
+ * such as deleting or releasing the message) or it reaches an age that is greater than
+ * the `noExtensionsAfterSecs` option. Functionally, this class could be distributed as a
+ * third party module and attached to a Squiss instance by the user, however the common
+ * and convenient use case is for this class to be used internally by Squiss itself.
+ *
+ * For efficient operation, the TimeoutExtender combines a doubly-linked list with a
+ * hash map, keeping an index of every message while not incurring the RAM or CPU overhead
+ * of having to re-create an array every time a message is deleted from the middle of a
+ * sorted queue. Every operation in this class has a time complexity of O(1) and a space
+ * complexity of O(n).
+ */
+class TimeoutExtender {
+
+  /**
+   * Creates a new TimeoutExtender.
+   * @param {Squiss} squiss The Squiss instance on which this extender should operate
+   * @param {Object} opts
+   */
+  constructor(squiss, opts) {
+    this._opts = Object.assign({}, optDefaults, opts)
+    this._head = null
+    this._tail = null
+    this._index = {}
+    this._timer = null
+    this._squiss = squiss
+    this._squiss.on('handled', msg => this.deleteMessage(msg))
+    this._squiss.on('message', msg => this.addMessage(msg))
+  }
+
+  /**
+   * Adds a new message to the tracker.
+   * @param {Message} message A Squiss Message object
+   */
+  addMessage(message) {
+    this._addNode({
+      message,
+      receivedOn: Date.now(),
+      timerOn: Date.now() - this._opts.visibilityTimeoutSecs - API_CALL_LEAD_SECS
+    })
+  }
+
+  /**
+   * Deletes a message from the tracker, if the message is currently being tracked.
+   * @param {Message} message A Squiss Message object
+   */
+  deleteMessage(message) {
+    const node = this._index[message.raw.MessageId]
+    if (node) this._deleteNode(node)
+  }
+
+  /**
+   * Adds a message wrapper node to the linked list and hash map index.
+   * @param {{message: Message, receivedOn: number, timerOn: number}} node The node
+   * object to be added
+   * @private
+   */
+  _addNode(node) {
+    this._index[node.message.raw.MessageId] = node
+    if (!this._head) {
+      this._head = node
+      this._tail = node
+      this._headChanged()
+    } else {
+      this._tail.next = node
+      node.prev = this._tail
+      this._tail = node
+    }
+  }
+
+  /**
+   * Deletes a message wrapper node from the linked list and hash map index.
+   * @param {{message: Message, receivedOn: number, timerOn: number}} node The node
+   * object to be removed
+   * @private
+   */
+  _deleteNode(node) {
+    const msgId = node.message.raw.MessageId
+    delete this._index[msgId]
+    if (this._head === node) {
+      this._head = node.next
+      if (this._head) delete this._head.prev
+      this._headChanged()
+    } else if (this._tail === node) {
+      this._tail = this._tail.prev
+      delete this._tail.next
+    } else {
+      node.prev.next = node.next
+      node.next.prev = node.prev
+    }
+  }
+
+  /**
+   * Called internally when the head of the linked list has changed in any way. This
+   * function is responsible for mantaining the timer that determines the tracker's next
+   * action.
+   * @returns {boolean} true if a timer was set in response to the changed head; false
+   * otherwise.
+   * @private
+   */
+  _headChanged() {
+    if (this._timer) clearTimeout(this._timer)
+    if (!this._head) return false
+    const node = this._head
+    this._timer = setTimeout(() => {
+      if (this._opts.noExtensionsAfterSecs) {
+        const age = Date.now() - node.receivedOn + API_CALL_LEAD_SECS
+        if (age >= this._opts.noExtensionsAfterSecs * 1000) this._deleteNode(node)
+        else this._renewNode(node)
+      }
+    }, Date.now() - node.timerOn)
+    return true
+  }
+
+  /**
+   * Extends the VisbilityTimeout of the message contained in the provided wrapper node,
+   * and moves the node to the tail of the linked list.
+   * @param {{message: Message, receivedOn: number, timerOn: number}} node The node
+   * object to be renewed
+   * @private
+   */
+  _renewNode(node) {
+    this._squiss.changeMessageVisibility(node.message,
+      this._opts.visibilityTimeoutSecs + API_CALL_LEAD_SECS)
+      .catch(err => {
+        this._squiss.emit('error', err)
+      })
+    this._deleteNode(node)
+    this._addNode(node)
+  }
+}
+
+module.exports = TimeoutExtender
+

--- a/src/TimeoutExtender.js
+++ b/src/TimeoutExtender.js
@@ -149,6 +149,7 @@ class TimeoutExtender {
    */
   _renewNode(node) {
     this._squiss.changeMessageVisibility(node.message, this._visTimeout + API_CALL_LEAD_MS)
+      .then(() => this._squiss.emit('timeoutExtended', node.message))
       .catch(err => {
         this._squiss.emit('error', err)
       })

--- a/src/TimeoutExtender.js
+++ b/src/TimeoutExtender.js
@@ -60,10 +60,11 @@ class TimeoutExtender {
    * @param {Message} message A Squiss Message object
    */
   addMessage(message) {
+    const now = Date.now()
     this._addNode({
       message,
-      receivedOn: Date.now(),
-      timerOn: Date.now() - this._visTimeout - API_CALL_LEAD_MS
+      receivedOn: now,
+      timerOn: now + this._visTimeout - API_CALL_LEAD_MS
     })
   }
 
@@ -132,10 +133,10 @@ class TimeoutExtender {
     this._timer = setTimeout(() => {
       if (this._stopAfter) {
         const age = Date.now() - node.receivedOn + API_CALL_LEAD_MS
-        if (age >= this._stopAfter) this._deleteNode(node)
-        else this._renewNode(node)
+        if (age >= this._stopAfter) return this._deleteNode(node)
       }
-    }, Date.now() - node.timerOn)
+      return this._renewNode(node)
+    }, node.timerOn - Date.now())
     return true
   }
 
@@ -152,6 +153,7 @@ class TimeoutExtender {
         this._squiss.emit('error', err)
       })
     this._deleteNode(node)
+    node.timerOn = Date.now() + this._visTimeout
     this._addNode(node)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,7 @@ class Squiss extends EventEmitter {
    *    expire. It will be extended by VisibilityTimeout + 5 seconds. The VisibilityTimeout used will be the one
    *    specified in opts.visibilityTimeoutSecs, or the queue's configured VisibilityTimeout if that option is not set.
    * @param {number} [opts.noExtensionsAfterSecs=0] The age, in seconds, at which a message will no longer have its
-   *    VisibilityTimeout automatically extended if opts.visibilityTimeoutSets is true.
+   *    VisibilityTimeout automatically extended if opts.autoExtendTimeout is true.
    * @param {Object} [opts.queuePolicy] If specified, will be set as the access policy of the queue when
    *    {@link #createQueue} is called. See http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html for
    *    more information.

--- a/src/index.js
+++ b/src/index.js
@@ -202,7 +202,7 @@ class Squiss extends EventEmitter {
    * @param {Message} msg The message object to be deleted
    */
   deleteMessage(msg) {
-    if (!(msg instanceof Message)) throw new Error('Squiss.deleteMessage requires a Message object')
+    if (!msg.raw) throw new Error('Squiss.deleteMessage requires a Message object')
     this._delQueue.push({ Id: msg.raw.MessageId, ReceiptHandle: msg.raw.ReceiptHandle })
     this.emit('delQueued', msg)
     this.handledMessage(msg)

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015-2016 TechnologyAdvice
+ * Copyright (c) 2015-2017 TechnologyAdvice
  */
 
 'use strict'
@@ -8,6 +8,7 @@ const AWS = require('aws-sdk')
 const EventEmitter = require('events').EventEmitter
 const Message = require('./Message')
 const url = require('url')
+const TimeoutExtender = require('./TimeoutExtender')
 
 /**
  * The maximum number of messages that can be sent in an SQS sendMessageBatch request.
@@ -33,7 +34,9 @@ const optDefaults = {
   idlePollIntervalMs: 0,
   delaySecs: 0,
   maxMessageBytes: 262144,
-  messageRetentionSecs: 345600
+  messageRetentionSecs: 345600,
+  autoExtendTimeout: false,
+  noExtensionsAfterSecs: 0
 }
 
 /**
@@ -94,6 +97,12 @@ class Squiss extends EventEmitter {
    * @param {number} [opts.messageRetentionSecs=345600] The amount of time for which to retain messages in the queue
    *    until they expire, in seconds. This is only used when calling {@link #createQueue}. Default is equivalent to
    *    4 days, maximum is 1209600 (14 days).
+   * @param {boolean} [opts.autoExtendTimeout=false] If true, the VisibilityTimeout for all in-flight messages will
+   *    be automatically extended when there are 5 seconds remaining before the VisibilityTimeout would normally
+   *    expire. It will be extended by VisibilityTimeout + 5 seconds. The VisibilityTimeout used will be the one
+   *    specified in opts.visibilityTimeoutSecs, or the queue's configured VisibilityTimeout if that option is not set.
+   * @param {number} [opts.noExtensionsAfterSecs=0] The age, in seconds, at which a message will no longer have its
+   *    VisibilityTimeout automatically extended if opts.visibilityTimeoutSets is true.
    * @param {Object} [opts.queuePolicy] If specified, will be set as the access policy of the queue when
    *    {@link #createQueue} is called. See http://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies.html for
    *    more information.
@@ -112,9 +121,11 @@ class Squiss extends EventEmitter {
     this._delQueue = []
     this._delTimer = null
     this._queueUrl = opts.queueUrl
+    this._queueVisibilityTimeout = null
     if (!opts.queueUrl && !opts.queueName) {
       throw new Error('Squiss requires either the "queueUrl", or the "queueName".')
     }
+    this._timeoutExtender = null
   }
 
   /**
@@ -188,15 +199,13 @@ class Squiss extends EventEmitter {
   /**
    * Queues the given message for deletion. The message will actually be deleted from SQS per the settings
    * supplied to the constructor.
-   * @param {Message|string} msg The message object to be deleted, or the receipt handle of a message to be deleted
+   * @param {Message} msg The message object to be deleted
    */
   deleteMessage(msg) {
-    if (msg instanceof Message) {
-      this._delQueue.push({ Id: msg.raw.MessageId, ReceiptHandle: msg.raw.ReceiptHandle })
-    } else {
-      this._delQueue.push({ Id: this._delQueue.length.toString(), ReceiptHandle: msg })
-    }
-    this.handledMessage()
+    if (!(msg instanceof Message)) throw new Error('Squiss.deleteMessage requires a Message object')
+    this._delQueue.push({ Id: msg.raw.MessageId, ReceiptHandle: msg.raw.ReceiptHandle })
+    this.emit('delQueued', msg)
+    this.handledMessage(msg)
     if (this._delQueue.length >= this._opts.deleteBatchSize) {
       if (this._delTimer) {
         clearTimeout(this._delTimer)
@@ -248,15 +257,39 @@ class Squiss extends EventEmitter {
   }
 
   /**
+   * Retrieves the VisibilityTimeout set on the target queue. When a message is received, it has this many
+   * seconds to be deleted before it will become available to be received again.
+   * @returns {Promise.<number>} The VisibilityTimeout setting of the target queue, in seconds
+   */
+  getQueueVisibilityTimeout() {
+    if (this._queueVisibilityTimeout) return Promise.resolve(this._queueVisibilityTimeout)
+    return this.getQueueUrl().then(QueueUrl => {
+      return sqs.getQueueAttributes({
+        AttributeNames: [ 'VisibilityTimeout' ],
+        QueueUrl
+      }).promise()
+    }).then(res => {
+      if (!res.Attributes || !res.Attributes.VisibilityTimeout) {
+        throw new Error('AWS.SQS.GetQueueAttributes call did not return expected shape. Response: ' +
+          JSON.stringify(res))
+      }
+      this._queueVisibilityTimeout = parseInt(res.Attributes.VisibilityTimeout, 10)
+      return this._queueVisibilityTimeout
+    })
+  }
+
+  /**
    * Informs Squiss that a message has been handled. This allows Squiss to decrement the number of in-flight
    * messages without deleting one, which may be necessary in the event of an error.
+   * @param {Message} msg The message to be handled
    */
-  handledMessage() {
+  handledMessage(msg) {
     this._inFlight--
     if (this._paused && this._slotsAvailable()) {
       this._paused = false
       this._startPoller()
     }
+    this.emit('handled', msg)
     if (!this._inFlight) {
       this.emit('drained')
     }
@@ -267,13 +300,16 @@ class Squiss extends EventEmitter {
    * {@link #handledMessage}. Note that if this is used when the poller is running, the message will be
    * immediately picked up and processed again (by this or any other application instance polling the same
    * queue).
-   * @param {Message|string} msg The Message object or ReceiptHandle for which to change the VisibilityTimeout.
+   * @param {Message} msg The Message object for which to change the VisibilityTimeout.
    * @returns {Promise} Resolves when the VisibilityTimeout has been changed. Rejects with the official AWS SDK's
    * error object.
    */
   releaseMessage(msg) {
-    this.handledMessage()
-    return this.changeMessageVisibility(msg, 0)
+    this.handledMessage(msg)
+    return this.changeMessageVisibility(msg, 0).then(res => {
+      this.emit('released', msg)
+      return res
+    })
   }
 
   /**
@@ -384,7 +420,10 @@ class Squiss extends EventEmitter {
       }).promise()
     }).then((data) => {
       if (data.Failed && data.Failed.length) {
-        data.Failed.forEach((fail) => this.emit('delError', fail))
+        data.Failed.forEach(fail => this.emit('delError', fail))
+      }
+      if (data.Successful && data.Successful.length) {
+        data.Successful.forEach(success => this.emit('deleted', success.Id))
       }
     }).catch((err) => {
       this.emit('error', err)
@@ -461,6 +500,25 @@ class Squiss extends EventEmitter {
   }
 
   /**
+   * Initializes the TimeoutExtender and associates it with this Squiss instance, if and only if the options passed
+   * to the constructor dictate that a TimeoutExtender is required.
+   * @returns {Promise} Resolves when the TimeoutExtender has been initialized
+   * @private
+   */
+  _initTimeoutExtender() {
+    if (!this._opts.autoExtendTimeout || this._timeoutExtender) return Promise.resolve()
+    return Promise.resolve().then(() => {
+      if (this._opts.visibilityTimeoutSecs) return this._opts.visibilityTimeoutSecs
+      return this.getQueueVisibilityTimeout()
+    }).then(visibilityTimeoutSecs => {
+      this._timeoutExtender = new TimeoutExtender(this, {
+        visibilityTimeoutSecs,
+        noExtensionsAfterSecs: this._opts.noExtensionsAfterSecs
+      })
+    })
+  }
+
+  /**
    * Sends a batch of a maximum of 10 messages to Amazon SQS. The Id generated for each will be the stringified
    * index of each message in the array, plus the startIndex
    * @param {Array<string|Object>} messages An array of messages to be sent. Objects will be JSON.stringified.
@@ -509,7 +567,8 @@ class Squiss extends EventEmitter {
    * @private
    */
   _startPoller() {
-    this.getQueueUrl()
+    this._initTimeoutExtender()
+      .then(() => this.getQueueUrl())
       .then(queueUrl => this._getBatch(queueUrl))
       .catch(e => this.emit('error', e))
   }

--- a/src/index.js
+++ b/src/index.js
@@ -264,7 +264,7 @@ class Squiss extends EventEmitter {
   getQueueVisibilityTimeout() {
     if (this._queueVisibilityTimeout) return Promise.resolve(this._queueVisibilityTimeout)
     return this.getQueueUrl().then(QueueUrl => {
-      return sqs.getQueueAttributes({
+      return this.sqs.getQueueAttributes({
         AttributeNames: [ 'VisibilityTimeout' ],
         QueueUrl
       }).promise()

--- a/src/index.js
+++ b/src/index.js
@@ -382,12 +382,12 @@ class Squiss extends EventEmitter {
 
   /**
    * Starts the poller, if it's not already running.
+   * @returns {Promise} Resolves when the poller has been started; resolves instantly if the poller is already running
    */
   start() {
-    if (!this._running) {
-      this._running = true
-      this._startPoller()
-    }
+    if (this._running) return Promise.resolve()
+    this._running = true
+    return this._startPoller()
   }
 
   /**
@@ -564,10 +564,11 @@ class Squiss extends EventEmitter {
 
   /**
    * Starts the polling process, regardless of the status of the this._running or this._paused flags.
+   * @returns {Promise} Resolves when the poller has started
    * @private
    */
   _startPoller() {
-    this._initTimeoutExtender()
+    return this._initTimeoutExtender()
       .then(() => this.getQueueUrl())
       .then(queueUrl => this._getBatch(queueUrl))
       .catch(e => this.emit('error', e))

--- a/test/src/TimeoutExtender.spec.js
+++ b/test/src/TimeoutExtender.spec.js
@@ -87,6 +87,17 @@ describe('TimeoutExtender', () => {
     clock.tick(6000)
     spy.should.be.calledOnce()
   })
+  it('emits "timeoutExtended" on renewal', done => {
+    clock = sinon.useFakeTimers(100000)
+    const squiss = new SquissStub()
+    squiss.on('timeoutExtended', msg => {
+      msg.should.equal(fooMsg)
+      done()
+    })
+    inst = new TimeoutExtender(squiss, { visibilityTimeoutSecs: 10 })
+    inst.addMessage(fooMsg)
+    clock.tick(6000)
+  })
   it('renews two messages approaching expiry', () => {
     clock = sinon.useFakeTimers(100000)
     const squiss = new SquissStub()

--- a/test/src/TimeoutExtender.spec.js
+++ b/test/src/TimeoutExtender.spec.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2015-2017 TechnologyAdvice
+ */
+
+'use strict'
+
+const TimeoutExtender = require('src/TimeoutExtender')
+const SquissStub = require('test/stubs/SquissStub')
+const Message = require('src/Message')
+const delay = require('delay')
+
+let inst = null
+const fooMsg = new Message({ msg: { MessageId: 'foo', Body: 'foo' } })
+const barMsg = new Message({ msg: { MessageId: 'bar', Body: 'bar' } })
+const bazMsg = new Message({ msg: { MessageId: 'baz', Body: 'baz' } })
+
+describe('TimeoutExtender', () => {
+  afterEach(() => {
+    inst = null
+  })
+  it('adds and deletes a message through function calls', () => {
+    inst = new TimeoutExtender(new SquissStub())
+    inst.addMessage(fooMsg)
+    inst._index.should.have.property('foo')
+    inst.deleteMessage(fooMsg)
+    inst._index.should.not.have.property('foo')
+  })
+  it('adds and deletes a message through events', () => {
+    const squiss = new SquissStub()
+    inst = new TimeoutExtender(squiss)
+    const addSpy = sinon.spy(inst, 'addMessage')
+    const delSpy = sinon.spy(inst, 'deleteMessage')
+    squiss.emit('message', fooMsg)
+    return delay(5).then(() => {
+      addSpy.should.be.calledOnce()
+      squiss.emit('handled', fooMsg)
+      return delay(5)
+    }).then(() => {
+      delSpy.should.be.calledOnce()
+    })
+  })
+  it('fails silently when asked to delete a nonexistent message', () => {
+    inst = new TimeoutExtender(new SquissStub())
+    inst.addMessage(fooMsg)
+    inst.deleteMessage(barMsg)
+  })
+  it('tracks multiple messages', () => {
+    inst = new TimeoutExtender(new SquissStub())
+    inst.addMessage(fooMsg)
+    inst.addMessage(barMsg)
+    inst._index.should.have.property('foo')
+    inst._index.should.have.property('bar')
+  })
+  it('deletes a head node', () => {
+    inst = new TimeoutExtender(new SquissStub())
+    inst.addMessage(fooMsg)
+    inst.addMessage(barMsg)
+    inst.addMessage(bazMsg)
+    inst.deleteMessage(fooMsg)
+    inst._head.message.raw.MessageId.should.equal('bar')
+  })
+  it('deletes a tail node', () => {
+    inst = new TimeoutExtender(new SquissStub())
+    inst.addMessage(fooMsg)
+    inst.addMessage(barMsg)
+    inst.addMessage(bazMsg)
+    inst.deleteMessage(bazMsg)
+    inst._tail.message.raw.MessageId.should.equal('bar')
+  })
+  it('deletes a middle node', () => {
+    inst = new TimeoutExtender(new SquissStub())
+    inst.addMessage(fooMsg)
+    inst.addMessage(barMsg)
+    inst.addMessage(bazMsg)
+    inst.deleteMessage(barMsg)
+    inst._head.next.message.raw.MessageId.should.equal('baz')
+  })
+})

--- a/test/src/TimeoutExtender.spec.js
+++ b/test/src/TimeoutExtender.spec.js
@@ -10,12 +10,14 @@ const Message = require('src/Message')
 const delay = require('delay')
 
 let inst = null
+let clock = null
 const fooMsg = new Message({ msg: { MessageId: 'foo', Body: 'foo' } })
 const barMsg = new Message({ msg: { MessageId: 'bar', Body: 'bar' } })
 const bazMsg = new Message({ msg: { MessageId: 'baz', Body: 'baz' } })
 
 describe('TimeoutExtender', () => {
   afterEach(() => {
+    if (clock && clock.restore) clock.restore()
     inst = null
   })
   it('adds and deletes a message through function calls', () => {
@@ -74,5 +76,51 @@ describe('TimeoutExtender', () => {
     inst.addMessage(bazMsg)
     inst.deleteMessage(barMsg)
     inst._head.next.message.raw.MessageId.should.equal('baz')
+  })
+  it('renews a message approaching expiry', () => {
+    clock = sinon.useFakeTimers(100000)
+    const squiss = new SquissStub()
+    const spy = sinon.spy(squiss, 'changeMessageVisibility')
+    inst = new TimeoutExtender(squiss, { visibilityTimeoutSecs: 10 })
+    inst.addMessage(fooMsg)
+    spy.should.not.be.called()
+    clock.tick(6000)
+    spy.should.be.calledOnce()
+  })
+  it('renews two messages approaching expiry', () => {
+    clock = sinon.useFakeTimers(100000)
+    const squiss = new SquissStub()
+    const spy = sinon.spy(squiss, 'changeMessageVisibility')
+    inst = new TimeoutExtender(squiss, { visibilityTimeoutSecs: 20 })
+    inst.addMessage(fooMsg)
+    clock.tick(10000)
+    inst.addMessage(barMsg)
+    spy.should.not.be.called()
+    clock.tick(10000)
+    spy.should.be.calledOnce()
+    clock.tick(10000)
+    spy.should.be.calledTwice()
+    clock.tick(10000)
+    spy.should.be.calledThrice()
+  })
+  it('renews only until the configured age limit', () => {
+    clock = sinon.useFakeTimers(100000)
+    const squiss = new SquissStub()
+    const spy = sinon.spy(squiss, 'changeMessageVisibility')
+    inst = new TimeoutExtender(squiss, { visibilityTimeoutSecs: 10, noExtensionsAfterSecs: 15 })
+    inst.addMessage(fooMsg)
+    clock.tick(10000)
+    spy.should.be.calledOnce()
+    clock.tick(20000)
+    spy.should.be.calledOnce()
+  })
+  it('emits error on the parent Squiss object in case of issue', done => {
+    clock = sinon.useFakeTimers(100000)
+    const squiss = new SquissStub()
+    squiss.on('error', () => done())
+    squiss.changeMessageVisibility = sinon.stub().returns(Promise.reject(new Error('test')))
+    inst = new TimeoutExtender(squiss, { visibilityTimeoutSecs: 10 })
+    inst.addMessage(fooMsg)
+    clock.tick(6000)
   })
 })

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -751,4 +751,24 @@ describe('index', () => {
       })
     })
   })
+  describe('auto-extensions', () => {
+    it('initializes a TimeoutExtender', () => {
+      inst = new Squiss({ queueUrl: 'foo', autoExtendTimeout: true })
+      inst.sqs = new SQSStub()
+      return inst.start().then(() => {
+        should.exist(inst._timeoutExtender)
+        inst._timeoutExtender.should.not.equal(null)
+        inst._timeoutExtender._opts.visibilityTimeoutSecs.should.equal(31)
+      })
+    })
+    it('constructs a TimeoutExtender with a custom VisibilityTimeout', () => {
+      inst = new Squiss({ queueUrl: 'foo', autoExtendTimeout: true, visibilityTimeoutSecs: 53 })
+      inst.sqs = new SQSStub()
+      return inst.start().then(() => {
+        should.exist(inst._timeoutExtender)
+        inst._timeoutExtender.should.not.equal(null)
+        inst._timeoutExtender._opts.visibilityTimeoutSecs.should.equal(53)
+      })
+    })
+  })
 })

--- a/test/src/index.spec.js
+++ b/test/src/index.spec.js
@@ -327,18 +327,6 @@ describe('index', () => {
         spy.should.be.calledTwice()
       })
     })
-    it('allows messages to be deleted by ReceiptHandle', () => {
-      inst = new Squiss({ queueUrl: 'foo', deleteBatchSize: 1 })
-      inst.sqs = new SQSStub(1)
-      const spy = sinon.spy(inst.sqs, 'deleteMessageBatch')
-      inst.on('message', (msg) => {
-        inst.deleteMessage(msg.raw.ReceiptHandle)
-      })
-      inst.start()
-      return wait().then(() => {
-        spy.should.be.calledOnce()
-      })
-    })
   })
   describe('Failures', () => {
     it('emits delError when a message fails to delete', () => {

--- a/test/stubs/SQSStub.js
+++ b/test/stubs/SQSStub.js
@@ -65,6 +65,16 @@ class SQSStub extends EventEmitter {
     })
   }
 
+  getQueueAttributes() {
+    return this._makeReq(() => {
+      return Promise.resolve({
+        Attributes: {
+          VisibilityTimeout: '31'
+        }
+      })
+    })
+  }
+
   receiveMessage(params) {
     return this._makeReq(() => {
       const msgs = this.msgs.splice(0, params.MaxNumberOfMessages)

--- a/test/stubs/SquissStub.js
+++ b/test/stubs/SquissStub.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2015-2017 TechnologyAdvice
+ */
+
+'use strict'
+
+const EventEmitter = require('events').EventEmitter
+
+class SquissStub extends EventEmitter {
+  changeMessageVisibility() {
+    return Promise.resolve()
+  }
+}
+
+module.exports = SquissStub


### PR DESCRIPTION
This feature is a breaking change, as it requires the full Squiss Message object to be passed to `Squiss.deleteMessage` and `Squiss.releaseMessage`, whereas those functions could previously operate on just a receiptHandle. It also requires the Message object to be passed to `Squiss.handledMessage`, whereas this function did not previously require any arguments. Therefore, the release following this merge will require a major version update.